### PR TITLE
[FIX] cd에서 dev, prod용 ec2 구분해서 배포

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -75,9 +75,9 @@ jobs:
       - name: Deploy to EC2
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USERNAME }}
-          key: ${{ secrets.EC2_SSH_KEY }}
+          host: ${{ secrets.EC2_DEV_HOST }}
+          username: ${{ secrets.EC2_DEV_USERNAME }}
+          key: ${{ secrets.EC2_DEV_SSH_KEY }}
           script: |
             DOCKER_IMAGE_TAG=${{ env.DOCKER_IMAGE_TAG }}
             DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -75,9 +75,9 @@ jobs:
       - name: Deploy to EC2
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USERNAME }}
-          key: ${{ secrets.EC2_SSH_KEY }}
+          host: ${{ secrets.EC2_PROD_HOST }}
+          username: ${{ secrets.EC2_PROD_USERNAME }}
+          key: ${{ secrets.EC2_PROD_SSH_KEY }}
           script: |
             DOCKER_IMAGE_TAG=${{ env.DOCKER_IMAGE_TAG }}
             DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
## 📄 PR 내용

- workflow에서 배포 할 때 dev용 ec2와 prod용 ec2를 구분해서 배포를 해야하기에 ec2 환경변수 명을 변경했습니다.

## 📝 수정 상세 내용 

- cd 파일에서 ec2 관련 환경변수 명 변경 ex) EC2_HOST를 EC2_DEV_HOST

## ✅ 체크리스트

- [x] 환경변수 명 변경

## 📍 레퍼런스

- x