### PR TITLE
Feature/#9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/doldol_server/doldol/common/config/SwaggerConfig.java
+++ b/src/main/java/doldol_server/doldol/common/config/SwaggerConfig.java
@@ -1,0 +1,36 @@
+package doldol_server.doldol.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile({"local", "dev"})
+public class SwaggerConfig {
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+			.info(new Info()
+				.title("Doldol Project API Document")
+				.description("Doldol 서버 API 명세서입니다.")
+				.version("v1.0.0")
+			).components(authComponent());
+	}
+
+	private Components authComponent() {
+		return new Components().addSecuritySchemes("jwt-token",
+			new SecurityScheme()
+				.type(SecurityScheme.Type.HTTP)
+				.in(SecurityScheme.In.HEADER)
+				.name("Authorization")
+				.scheme("bearer")
+				.bearerFormat("JWT"));
+	}
+}
+

--- a/src/main/java/doldol_server/doldol/common/entity/BaseEntity.java
+++ b/src/main/java/doldol_server/doldol/common/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package doldol_server.doldol.common.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+	@CreatedDate
+	@Column(nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(nullable = false)
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/doldol_server/doldol/common/exception/CustomException.java
+++ b/src/main/java/doldol_server/doldol/common/exception/CustomException.java
@@ -1,0 +1,18 @@
+package doldol_server.doldol.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException{
+	private final ErrorCode errorCode;
+
+	protected CustomException(ErrorCode errorCode, String message) {
+		super(errorCode.getMessage() + ": " + message);
+		this.errorCode = errorCode;
+	}
+
+	protected CustomException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/doldol_server/doldol/common/exception/ErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/ErrorCode.java
@@ -1,0 +1,19 @@
+package doldol_server.doldol.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+	/**
+	 * 데이터 유효성 검사 실패
+	 */
+	INVALID_VALUE(HttpStatus.BAD_REQUEST, "D-001", "잘못된 요청입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/doldol_server/doldol/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/doldol_server/doldol/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package doldol_server.doldol.common.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import doldol_server.doldol.common.response.ErrorResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	/**
+	 * 커스텀 예외
+	 */
+	@ExceptionHandler(value = CustomException.class)
+	public ResponseEntity<ErrorResponse<Void>> handleCustomException(CustomException e) {
+		ErrorCode errorCode = e.getErrorCode();
+		return ResponseEntity.status(errorCode.getHttpStatus())
+			.body(ErrorResponse.error(errorCode.getCode(), errorCode.getMessage()));
+	}
+
+	/**
+	 * 데이터 유효성 검사가 실패할 경우
+	 */
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	protected ResponseEntity<ErrorResponse<Map<String, String>>> handleMethodArgumentNotValidException(
+		MethodArgumentNotValidException e) {
+		Map<String, String> errors = new HashMap<>();
+
+		BindingResult bindingResult = e.getBindingResult();
+		for (FieldError er : bindingResult.getFieldErrors()) {
+			errors.put(er.getField(), er.getDefaultMessage());
+		}
+
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+			.body(ErrorResponse.error(errors, ErrorCode.INVALID_VALUE.getCode(),
+				ErrorCode.INVALID_VALUE.getMessage()));
+	}
+}

--- a/src/main/java/doldol_server/doldol/common/response/ApiResponse.java
+++ b/src/main/java/doldol_server/doldol/common/response/ApiResponse.java
@@ -1,0 +1,32 @@
+package doldol_server.doldol.common.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+	@Schema(name = "성공 응답에 대한 데이터")
+	private final T data;
+	@Schema(name = "HTTP 상태코드", example = "200")
+	private final int status;
+	@Schema(name = "요청 성공 메세지", example = "OK")
+	private final String message;
+
+	private ApiResponse(T data, int status, String message) {
+		this.data = data;
+		this.status = status;
+		this.message = message;
+	}
+
+	public static <T> ApiResponse<T> ok(T data) {
+		return new ApiResponse<>(data, 200, "OK");
+	}
+
+	public static <T> ApiResponse<T> created(T data) {
+		return new ApiResponse<>(data, 201, "CREATED");
+	}
+
+	public static ApiResponse<Void> noContent() {
+		return new ApiResponse<>(null, 204, "NO_CONTENT");
+	}
+}

--- a/src/main/java/doldol_server/doldol/common/response/ApiResponse.java
+++ b/src/main/java/doldol_server/doldol/common/response/ApiResponse.java
@@ -5,11 +5,11 @@ import lombok.Getter;
 
 @Getter
 public class ApiResponse<T> {
-	@Schema(name = "성공 응답에 대한 데이터")
+	@Schema(description = "성공 응답에 대한 데이터")
 	private final T data;
-	@Schema(name = "HTTP 상태코드", example = "200")
+	@Schema(description = "HTTP 상태코드", example = "200")
 	private final int status;
-	@Schema(name = "요청 성공 메세지", example = "OK")
+	@Schema(description = "요청 성공 메세지", example = "OK")
 	private final String message;
 
 	private ApiResponse(T data, int status, String message) {

--- a/src/main/java/doldol_server/doldol/common/response/ErrorResponse.java
+++ b/src/main/java/doldol_server/doldol/common/response/ErrorResponse.java
@@ -1,0 +1,30 @@
+package doldol_server.doldol.common.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse<T> {
+
+	@Schema(name = "에러가 발생한 내용")
+	private final T data;
+	@Schema(name = "에러 코드 [알파벳-숫자]", example = "D-001")
+	private final String code;
+	@Schema(name = "에러 메세지", example = "잘못된 요청입니다.")
+	private final String message;
+
+	private ErrorResponse(T data, String code, String message) {
+		this.data = data;
+		this.code = code;
+		this.message = message;
+	}
+
+	public static ErrorResponse<Void> error(String code, String message) {
+		return error(null, code, message);
+	}
+
+	public static <T> ErrorResponse<T> error(T data, String code, String message) {
+		return new ErrorResponse<>(data, code, message);
+	}
+
+}

--- a/src/main/java/doldol_server/doldol/common/response/ErrorResponse.java
+++ b/src/main/java/doldol_server/doldol/common/response/ErrorResponse.java
@@ -6,11 +6,11 @@ import lombok.Getter;
 @Getter
 public class ErrorResponse<T> {
 
-	@Schema(name = "에러가 발생한 내용")
+	@Schema(description = "에러가 발생한 내용")
 	private final T data;
-	@Schema(name = "에러 코드 [알파벳-숫자]", example = "D-001")
+	@Schema(description = "에러 코드 [알파벳-숫자]", example = "D-001")
 	private final String code;
-	@Schema(name = "에러 메세지", example = "잘못된 요청입니다.")
+	@Schema(description = "에러 메세지", example = "잘못된 요청입니다.")
 	private final String message;
 
 	private ErrorResponse(T data, String code, String message) {


### PR DESCRIPTION
## 📄 PR 내용

<!--- 작업에 대한 요약 설명을 작성해 주세요. -->
- #9 

## 📝 수정 상세 내용 
<!--- 작업 전과 후의 변화를 설명해 주세요. -->

### 성공/실패 응답 각각 구현
 - 컨트롤러에서 성공 응답을 통합하기 위하여 커스텀한 성공 응답을 구현했습니다.
  
    ```java
    // Controller
    ...
    return ApiResponse.ok(messageResponse);
    ```
 - 실패 공통 응답은 `GlobalExceptionHandler`이나 인증 관련 필터에서 사용될 예정입니다.

### 커스텀 예외
 - 예외를 통합 처리하기 위해 `CustomException`과 이를 처리하는 `GlobalExceptionHandler`를 구현하였습니다.
- 커스텀된 예외 메세지를 관리하기 위해 `ErrorCode`를 구현하였습니다.
    ```java
    NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "D-001", "잘못된 요청입니다.")
    ```
 - 에외가 발생한 시점에 다음과 같이 작성해주시면 됩니다.
    ```java
    throw new CustomException(ErrorCode.NOT_FOUND_USER);
    throw new CustomException(NOT_FOUND_USER); // ErrorCode static import
    ~.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
    ```

### 스웨거 설정
-  API 관리에 쓰이는 도구인 스웨거를 도입했습니다. 요청, 응답 데이터에 대한 정의를 제공하고, 직접 API를 호출할 수 있어 매우 편리한 도구입니다.
- JWT 인증을 위한 인증 컴포넌트를 추가하였습니다.

### 베이스 엔티티
- 모든 엔티티에서 필요한 생성, 수정 시간에 대한 필드를 가지고 있는 추상 클래스입니다. 
- 모든 엔티티에서 `extends` 해서 써주사면 됩니다.

## ✅ 체크리스트

- [x] 성공/실패 응답 포맷
- [x] 스웨거 설정
- [x] 커스텀 예외
- [x] 베이스 엔티티

## 📍 레퍼런스