### PR TITLE
[FEAT] DOMAIN 생성 - 신고, 참여 내역

### DIFF
--- a/src/main/java/doldol_server/doldol/complaint/entity/Complaint.java
+++ b/src/main/java/doldol_server/doldol/complaint/entity/Complaint.java
@@ -1,6 +1,7 @@
 package doldol_server.doldol.complaint.entity;
 
 import doldol_server.doldol.user.User;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -16,7 +17,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Table(name = "complaint")
-public class complaint {
+public class Complaint {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,14 +34,23 @@ public class complaint {
 	private User admin;
 
 	// 롤링페이퍼 id
-	private Long paperId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "paper_id")
+	private Paper paper;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "message_id")
+	private Message message;
 
 	// 내용
+	@Column(name = "content", nullable = false)
 	private String content;
 
 	// 답변
+	@Column(name = "answer")
 	private String answer;
 
 	// 해결 유무
+	@Column(name = "is_solved", nullable = false)
 	private boolean isSolved;
 }

--- a/src/main/java/doldol_server/doldol/complaint/entity/complaint.java
+++ b/src/main/java/doldol_server/doldol/complaint/entity/complaint.java
@@ -1,0 +1,46 @@
+package doldol_server.doldol.complaint.entity;
+
+import doldol_server.doldol.user.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "complaint")
+public class complaint {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	// 신고자
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	// 관리자
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User admin;
+
+	// 롤링페이퍼 id
+	private Long paperId;
+
+	// 내용
+	private String content;
+
+	// 답변
+	private String answer;
+
+	// 해결 유무
+	private boolean isSolved;
+}

--- a/src/main/java/doldol_server/doldol/rollingPaper/entity/Participant.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/entity/Participant.java
@@ -1,0 +1,48 @@
+package doldol_server.doldol.rollingPaper.entity;
+
+import doldol_server.doldol.user.User;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "participant")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class Participant {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	// 참여자 아이디
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	// 롤링페이퍼 아이디
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "paper_id")
+	private Paper paper;
+
+	// 참여자가 쓴 메시지 아이디
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "meesage_id")
+	private Message message;
+
+	// 방장 여부
+	@Column(name = "is_master", nullable = false)
+	private boolean isMaster;
+}

--- a/src/main/java/doldol_server/doldol/user/Role.java
+++ b/src/main/java/doldol_server/doldol/user/Role.java
@@ -1,0 +1,13 @@
+package doldol_server.doldol.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    ADMIN("ROLE_ADMIN"), USER("ROLE_USER");
+
+    private final String role;
+}

--- a/src/main/java/doldol_server/doldol/user/SocialType.java
+++ b/src/main/java/doldol_server/doldol/user/SocialType.java
@@ -1,0 +1,18 @@
+package doldol_server.doldol.user;
+
+import java.util.Arrays;
+
+public enum SocialType {
+    KAKAO;
+
+    public static SocialType getSocialType(String socialTypeStr) {
+        if (socialTypeStr == null) {
+            throw new RuntimeException("소셜 타입이 null입니다.");
+        }
+
+        return Arrays.stream(SocialType.values())
+                .filter(type -> type.name().equalsIgnoreCase(socialTypeStr))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 소셜 타입입니다."));
+    }
+}

--- a/src/main/java/doldol_server/doldol/user/User.java
+++ b/src/main/java/doldol_server/doldol/user/User.java
@@ -1,0 +1,65 @@
+package doldol_server.doldol.user;
+
+import doldol_server.doldol.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Table(name = "USERS")
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(name = "id", unique = true)
+    private String loginId;
+
+    @Column(name = "password")
+    private String password;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "phone_number", unique = true)
+    private String phoneNumber;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "social_type")
+    private SocialType socialType;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "role")
+    private Role role;
+
+    @Column(name = "social_id", unique = true)
+    private String socialId;
+
+    @Column(name = "is_deleted")
+    private boolean isDeleted = false;
+
+    @Builder
+    public User(String loginId, String name, String password, String phoneNumber, Role role, String socialId,
+                SocialType socialType) {
+        this.loginId = loginId;
+        this.name = name;
+        this.password = password;
+        this.phoneNumber = phoneNumber;
+        this.role = role;
+        this.socialId = socialId;
+        this.socialType = socialType;
+    }
+}


### PR DESCRIPTION
## 📄 PR 내용

<!--- 작업에 대한 요약 설명을 작성해 주세요. -->

- 신고와 참여 내역 엔티티를 생성하고, 연결 관계를 설정해주었습니다.

## 📝 수정 상세 내용 

<!--- 작업 전과 후의 변화를 설명해 주세요. -->

- 신고 엔티티의 신고자/관리자 -> 유저 엔티티와 조인 (ManyToOne)
- 신고 엔티티의 롤링페이퍼 정보 -> 롤링페이퍼 엔티티와 조인 (ManyToOne)
- 신고 엔티티의 메시지 정보 -> 메시지 엔티티와 조인 (ManyToOne)

- 참여 내역의 참여자 정보 -> 유저 엔티티와 조인 (ManyToOne)
- 참여 내역의 롤링페이퍼 정보 -> 롤링페이퍼 엔티티와 조인 (ManyToOne)
- 참여 내역의 메시지 정보 -> 메시지 엔티티와 조인 (OnetoOne)

## ✅ 체크리스트

- [ ] 신고 엔티티
- [ ] 참여 내역 엔티티
- [ ] 관계 설정

## 📍 레퍼런스

- DolDol ERD Cloud