### PR TITLE
[FEAT] 도메인 - 신고, 참여 내역

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/doldol_server/doldol/common/config/SwaggerConfig.java
+++ b/src/main/java/doldol_server/doldol/common/config/SwaggerConfig.java
@@ -1,0 +1,36 @@
+package doldol_server.doldol.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile({"local", "dev"})
+public class SwaggerConfig {
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+			.info(new Info()
+				.title("Doldol Project API Document")
+				.description("Doldol 서버 API 명세서입니다.")
+				.version("v1.0.0")
+			).components(authComponent());
+	}
+
+	private Components authComponent() {
+		return new Components().addSecuritySchemes("jwt-token",
+			new SecurityScheme()
+				.type(SecurityScheme.Type.HTTP)
+				.in(SecurityScheme.In.HEADER)
+				.name("Authorization")
+				.scheme("bearer")
+				.bearerFormat("JWT"));
+	}
+}
+

--- a/src/main/java/doldol_server/doldol/common/entity/BaseEntity.java
+++ b/src/main/java/doldol_server/doldol/common/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package doldol_server.doldol.common.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+	@CreatedDate
+	@Column(nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(nullable = false)
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/doldol_server/doldol/common/exception/CustomException.java
+++ b/src/main/java/doldol_server/doldol/common/exception/CustomException.java
@@ -1,0 +1,18 @@
+package doldol_server.doldol.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException{
+	private final ErrorCode errorCode;
+
+	protected CustomException(ErrorCode errorCode, String message) {
+		super(errorCode.getMessage() + ": " + message);
+		this.errorCode = errorCode;
+	}
+
+	protected CustomException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/doldol_server/doldol/common/exception/ErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/ErrorCode.java
@@ -1,0 +1,19 @@
+package doldol_server.doldol.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+	/**
+	 * 데이터 유효성 검사 실패
+	 */
+	INVALID_VALUE(HttpStatus.BAD_REQUEST, "D-001", "잘못된 요청입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/doldol_server/doldol/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/doldol_server/doldol/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package doldol_server.doldol.common.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import doldol_server.doldol.common.response.ErrorResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	/**
+	 * 커스텀 예외
+	 */
+	@ExceptionHandler(value = CustomException.class)
+	public ResponseEntity<ErrorResponse<Void>> handleCustomException(CustomException e) {
+		ErrorCode errorCode = e.getErrorCode();
+		return ResponseEntity.status(errorCode.getHttpStatus())
+			.body(ErrorResponse.error(errorCode.getCode(), errorCode.getMessage()));
+	}
+
+	/**
+	 * 데이터 유효성 검사가 실패할 경우
+	 */
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	protected ResponseEntity<ErrorResponse<Map<String, String>>> handleMethodArgumentNotValidException(
+		MethodArgumentNotValidException e) {
+		Map<String, String> errors = new HashMap<>();
+
+		BindingResult bindingResult = e.getBindingResult();
+		for (FieldError er : bindingResult.getFieldErrors()) {
+			errors.put(er.getField(), er.getDefaultMessage());
+		}
+
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+			.body(ErrorResponse.error(errors, ErrorCode.INVALID_VALUE.getCode(),
+				ErrorCode.INVALID_VALUE.getMessage()));
+	}
+}

--- a/src/main/java/doldol_server/doldol/common/response/ApiResponse.java
+++ b/src/main/java/doldol_server/doldol/common/response/ApiResponse.java
@@ -1,0 +1,32 @@
+package doldol_server.doldol.common.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+	@Schema(name = "성공 응답에 대한 데이터")
+	private final T data;
+	@Schema(name = "HTTP 상태코드", example = "200")
+	private final int status;
+	@Schema(name = "요청 성공 메세지", example = "OK")
+	private final String message;
+
+	private ApiResponse(T data, int status, String message) {
+		this.data = data;
+		this.status = status;
+		this.message = message;
+	}
+
+	public static <T> ApiResponse<T> ok(T data) {
+		return new ApiResponse<>(data, 200, "OK");
+	}
+
+	public static <T> ApiResponse<T> created(T data) {
+		return new ApiResponse<>(data, 201, "CREATED");
+	}
+
+	public static ApiResponse<Void> noContent() {
+		return new ApiResponse<>(null, 204, "NO_CONTENT");
+	}
+}

--- a/src/main/java/doldol_server/doldol/common/response/ApiResponse.java
+++ b/src/main/java/doldol_server/doldol/common/response/ApiResponse.java
@@ -5,11 +5,11 @@ import lombok.Getter;
 
 @Getter
 public class ApiResponse<T> {
-	@Schema(name = "성공 응답에 대한 데이터")
+	@Schema(description = "성공 응답에 대한 데이터")
 	private final T data;
-	@Schema(name = "HTTP 상태코드", example = "200")
+	@Schema(description = "HTTP 상태코드", example = "200")
 	private final int status;
-	@Schema(name = "요청 성공 메세지", example = "OK")
+	@Schema(description = "요청 성공 메세지", example = "OK")
 	private final String message;
 
 	private ApiResponse(T data, int status, String message) {

--- a/src/main/java/doldol_server/doldol/common/response/ErrorResponse.java
+++ b/src/main/java/doldol_server/doldol/common/response/ErrorResponse.java
@@ -1,0 +1,30 @@
+package doldol_server.doldol.common.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse<T> {
+
+	@Schema(name = "에러가 발생한 내용")
+	private final T data;
+	@Schema(name = "에러 코드 [알파벳-숫자]", example = "D-001")
+	private final String code;
+	@Schema(name = "에러 메세지", example = "잘못된 요청입니다.")
+	private final String message;
+
+	private ErrorResponse(T data, String code, String message) {
+		this.data = data;
+		this.code = code;
+		this.message = message;
+	}
+
+	public static ErrorResponse<Void> error(String code, String message) {
+		return error(null, code, message);
+	}
+
+	public static <T> ErrorResponse<T> error(T data, String code, String message) {
+		return new ErrorResponse<>(data, code, message);
+	}
+
+}

--- a/src/main/java/doldol_server/doldol/common/response/ErrorResponse.java
+++ b/src/main/java/doldol_server/doldol/common/response/ErrorResponse.java
@@ -6,11 +6,11 @@ import lombok.Getter;
 @Getter
 public class ErrorResponse<T> {
 
-	@Schema(name = "에러가 발생한 내용")
+	@Schema(description = "에러가 발생한 내용")
 	private final T data;
-	@Schema(name = "에러 코드 [알파벳-숫자]", example = "D-001")
+	@Schema(description = "에러 코드 [알파벳-숫자]", example = "D-001")
 	private final String code;
-	@Schema(name = "에러 메세지", example = "잘못된 요청입니다.")
+	@Schema(description = "에러 메세지", example = "잘못된 요청입니다.")
 	private final String message;
 
 	private ErrorResponse(T data, String code, String message) {

--- a/src/main/java/doldol_server/doldol/complaint/entity/Complaint.java
+++ b/src/main/java/doldol_server/doldol/complaint/entity/Complaint.java
@@ -1,6 +1,7 @@
 package doldol_server.doldol.complaint.entity;
 
 import doldol_server.doldol.user.User;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -16,7 +17,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Table(name = "complaint")
-public class complaint {
+public class Complaint {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,14 +34,23 @@ public class complaint {
 	private User admin;
 
 	// 롤링페이퍼 id
-	private Long paperId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "paper_id")
+	private Paper paper;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "message_id")
+	private Message message;
 
 	// 내용
+	@Column(name = "content", nullable = false)
 	private String content;
 
 	// 답변
+	@Column(name = "answer")
 	private String answer;
 
 	// 해결 유무
+	@Column(name = "is_solved", nullable = false)
 	private boolean isSolved;
 }

--- a/src/main/java/doldol_server/doldol/complaint/entity/Complaint.java
+++ b/src/main/java/doldol_server/doldol/complaint/entity/Complaint.java
@@ -23,17 +23,10 @@ public class Complaint {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	// 신고자
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
 
-	// 관리자
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id")
-	private User admin;
-
-	// 롤링페이퍼 id
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "paper_id")
 	private Paper paper;
@@ -42,15 +35,12 @@ public class Complaint {
 	@JoinColumn(name = "message_id")
 	private Message message;
 
-	// 내용
 	@Column(name = "content", nullable = false)
 	private String content;
 
-	// 답변
 	@Column(name = "answer")
 	private String answer;
 
-	// 해결 유무
 	@Column(name = "is_solved", nullable = false)
 	private boolean isSolved;
 }

--- a/src/main/java/doldol_server/doldol/complaint/entity/complaint.java
+++ b/src/main/java/doldol_server/doldol/complaint/entity/complaint.java
@@ -1,0 +1,46 @@
+package doldol_server.doldol.complaint.entity;
+
+import doldol_server.doldol.user.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "complaint")
+public class complaint {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	// 신고자
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	// 관리자
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User admin;
+
+	// 롤링페이퍼 id
+	private Long paperId;
+
+	// 내용
+	private String content;
+
+	// 답변
+	private String answer;
+
+	// 해결 유무
+	private boolean isSolved;
+}

--- a/src/main/java/doldol_server/doldol/rollingPaper/entity/Participant.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/entity/Participant.java
@@ -1,0 +1,48 @@
+package doldol_server.doldol.rollingPaper.entity;
+
+import doldol_server.doldol.user.User;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "participant")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class Participant {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	// 참여자 아이디
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	// 롤링페이퍼 아이디
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "paper_id")
+	private Paper paper;
+
+	// 참여자가 쓴 메시지 아이디
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "meesage_id")
+	private Message message;
+
+	// 방장 여부
+	@Column(name = "is_master", nullable = false)
+	private boolean isMaster;
+}

--- a/src/main/java/doldol_server/doldol/rollingPaper/entity/Participant.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/entity/Participant.java
@@ -1,7 +1,6 @@
 package doldol_server.doldol.rollingPaper.entity;
 
 import doldol_server.doldol.user.User;
-import jakarta.annotation.Nullable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -27,22 +26,18 @@ public class Participant {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	// 참여자 아이디
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
 
-	// 롤링페이퍼 아이디
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "paper_id")
 	private Paper paper;
 
-	// 참여자가 쓴 메시지 아이디
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "meesage_id")
 	private Message message;
 
-	// 방장 여부
 	@Column(name = "is_master", nullable = false)
 	private boolean isMaster;
 }

--- a/src/main/java/doldol_server/doldol/user/Role.java
+++ b/src/main/java/doldol_server/doldol/user/Role.java
@@ -1,0 +1,13 @@
+package doldol_server.doldol.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    ADMIN("ROLE_ADMIN"), USER("ROLE_USER");
+
+    private final String role;
+}

--- a/src/main/java/doldol_server/doldol/user/SocialType.java
+++ b/src/main/java/doldol_server/doldol/user/SocialType.java
@@ -1,0 +1,18 @@
+package doldol_server.doldol.user;
+
+import java.util.Arrays;
+
+public enum SocialType {
+    KAKAO;
+
+    public static SocialType getSocialType(String socialTypeStr) {
+        if (socialTypeStr == null) {
+            throw new RuntimeException("소셜 타입이 null입니다.");
+        }
+
+        return Arrays.stream(SocialType.values())
+                .filter(type -> type.name().equalsIgnoreCase(socialTypeStr))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 소셜 타입입니다."));
+    }
+}

--- a/src/main/java/doldol_server/doldol/user/User.java
+++ b/src/main/java/doldol_server/doldol/user/User.java
@@ -1,0 +1,65 @@
+package doldol_server.doldol.user;
+
+import doldol_server.doldol.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Table(name = "USERS")
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(name = "id", unique = true)
+    private String loginId;
+
+    @Column(name = "password")
+    private String password;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "phone_number", unique = true)
+    private String phoneNumber;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "social_type")
+    private SocialType socialType;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "role")
+    private Role role;
+
+    @Column(name = "social_id", unique = true)
+    private String socialId;
+
+    @Column(name = "is_deleted")
+    private boolean isDeleted = false;
+
+    @Builder
+    public User(String loginId, String name, String password, String phoneNumber, Role role, String socialId,
+                SocialType socialType) {
+        this.loginId = loginId;
+        this.name = name;
+        this.password = password;
+        this.phoneNumber = phoneNumber;
+        this.role = role;
+        this.socialId = socialId;
+        this.socialType = socialType;
+    }
+}


### PR DESCRIPTION
## 📄 PR 내용

<!--- 작업에 대한 요약 설명을 작성해 주세요. -->

- 신고와 참여 내역 엔티티를 생성하고, 연결 관계를 설정해주었습니다.

## 📝 수정 상세 내용 

<!--- 작업 전과 후의 변화를 설명해 주세요. -->

- 신고 엔티티의 신고자/관리자 -> 유저 엔티티와 조인 (ManyToOne)
- 신고 엔티티의 롤링페이퍼 정보 -> 롤링페이퍼 엔티티와 조인 (ManyToOne)
- 신고 엔티티의 메시지 정보 -> 메시지 엔티티와 조인 (ManyToOne)

- 참여 내역의 참여자 정보 -> 유저 엔티티와 조인 (ManyToOne)
- 참여 내역의 롤링페이퍼 정보 -> 롤링페이퍼 엔티티와 조인 (ManyToOne)
- 참여 내역의 메시지 정보 -> 메시지 엔티티와 조인 (OnetoOne)

## ✅ 체크리스트

- [ ] 신고 엔티티
- [ ] 참여 내역 엔티티
- [ ] 관계 설정

## 📍 레퍼런스

- DolDol ERD Cloud