### PR TITLE
[FEAT] 자체 서비스 회원가입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,13 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	// Mail Sender
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	// Thymeleaf
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 }
 
 tasks.named('test') {

--- a/src/main/java/doldol_server/doldol/auth/controller/AuthController.java
+++ b/src/main/java/doldol_server/doldol/auth/controller/AuthController.java
@@ -1,27 +1,76 @@
 package doldol_server.doldol.auth.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import doldol_server.doldol.auth.dto.request.JoinRequest;
+import doldol_server.doldol.auth.dto.request.EmailCodeSendRequest;
+import doldol_server.doldol.auth.dto.request.EmailCodeVerifyRequest;
+import doldol_server.doldol.auth.dto.request.FinalJoinRequest;
+import doldol_server.doldol.auth.dto.request.IdCheckRequest;
+import doldol_server.doldol.auth.dto.request.TempJoinRequest;
+import doldol_server.doldol.auth.service.AuthService;
 import doldol_server.doldol.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @Tag(name = "회원가입")
 @RestController
 @RequestMapping("/auth")
+@RequiredArgsConstructor
 public class AuthController {
+
+	private final AuthService authService;
+
+	@PostMapping("/check-id")
+	@Operation(
+		summary = "아이디 중복 확인 API",
+		description = "이이디 중복 확인")
+	public ResponseEntity<ApiResponse<Void>> checkIdDuplicate(@RequestBody IdCheckRequest idCheckRequest) {
+		authService.checkIdDuplicate(idCheckRequest.id());
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.noContent());
+	}
+
+	@PostMapping("/temp-join")
+	@Operation(
+		summary = "임시 회원가입 API",
+		description = "임시 회원가입")
+	public ResponseEntity<ApiResponse<Void>> tempJoin(@RequestBody @Valid TempJoinRequest tempJoinRequest) {
+		authService.tempJoin(tempJoinRequest);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.noContent());
+	}
+
+	@PostMapping("/email/send-code")
+	@Operation(
+		summary = "이메일 인증 코드 전송 API",
+		description = "이메일 인증 코드 전송")
+	public ResponseEntity<ApiResponse<Void>> sendVerificationCode(
+		@RequestBody @Valid EmailCodeSendRequest emailCodeSendRequest) {
+		authService.sendVerificationCode(emailCodeSendRequest.email());
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.noContent());
+	}
+
+	@PostMapping("/email/verify-code")
+	@Operation(
+		summary = "이메일 인증 코드 검증 API",
+		description = "이메일 인증 코드 검증")
+	public ResponseEntity<ApiResponse<Void>> validateVerificationCode(
+		@RequestBody @Valid EmailCodeVerifyRequest emailCodeVerifyRequest) {
+		authService.validateVerificationCode(emailCodeVerifyRequest.email(), emailCodeVerifyRequest.code());
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.noContent());
+	}
 
 	@PostMapping("/join")
 	@Operation(
-		summary = "회원가입 API",
-		description = "회원가입")
-	public ApiResponse<Void> join(
-		@RequestBody @Valid JoinRequest request) {
-		return ApiResponse.noContent();
+		summary = "회원가입 완료 API",
+		description = "회원가입 완료")
+	public ResponseEntity<ApiResponse<Void>> join(@RequestBody @Valid FinalJoinRequest finalJoinRequest) {
+		authService.join(finalJoinRequest.email());
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.noContent());
 	}
 }

--- a/src/main/java/doldol_server/doldol/auth/dto/request/EmailCodeSendRequest.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/request/EmailCodeSendRequest.java
@@ -1,0 +1,11 @@
+package doldol_server.doldol.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailCodeSendRequest(@NotBlank(message = "이메일은 필수 입력값입니다.")
+								   @Email(message = "올바른 이메일 양식을 입력해주세요.")
+								   @Schema(description = "이메일", example = "doldol@test.com")
+								   String email) {
+}

--- a/src/main/java/doldol_server/doldol/auth/dto/request/EmailCodeVerifyRequest.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/request/EmailCodeVerifyRequest.java
@@ -1,0 +1,14 @@
+package doldol_server.doldol.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailCodeVerifyRequest(@NotBlank(message = "이메일은 필수 입력값입니다.")
+									 @Email(message = "올바른 이메일 양식을 입력해주세요.")
+									 @Schema(description = "이메일", example = "doldol@test.com")
+									 String email,
+									 @NotBlank(message = "인증번호는 필수 입력값입니다.")
+									 @Schema(description = "인증번호", example = "123456")
+									 String code) {
+}

--- a/src/main/java/doldol_server/doldol/auth/dto/request/FinalJoinRequest.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/request/FinalJoinRequest.java
@@ -1,0 +1,11 @@
+package doldol_server.doldol.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record FinalJoinRequest(@NotBlank(message = "이메일은 필수 입력값입니다.")
+							   @Email(message = "올바른 이메일 양식을 입력해주세요.")
+							   @Schema(description = "이메일", example = "doldol@test.com")
+							   String email) {
+}

--- a/src/main/java/doldol_server/doldol/auth/dto/request/IdCheckRequest.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/request/IdCheckRequest.java
@@ -1,0 +1,12 @@
+package doldol_server.doldol.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record IdCheckRequest(
+	@NotBlank(message = "아이디는 필수 입력값입니다.")
+	@Pattern(regexp = "^[a-z0-9]{4,20}$", message = "아이디는 영어 소문자와 숫자만 사용하여 4~20자리여야 합니다.")
+	@Schema(description = "아이디는 입력되어야 합니다. 아이디는 영어 소문자와 숫자만 사용하여 4~20자리입니다", example = "doldol1234")
+	String id) {
+}

--- a/src/main/java/doldol_server/doldol/auth/dto/request/TempJoinRequest.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/request/TempJoinRequest.java
@@ -1,0 +1,43 @@
+package doldol_server.doldol.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record TempJoinRequest(
+	@NotBlank(message = "아이디는 필수 입력값입니다.")
+	@Pattern(regexp = "^[a-z0-9]{4,20}$", message = "아이디는 영어 소문자와 숫자만 사용하여 4~20자리여야 합니다.")
+	@Schema(description = "아이디는 입력되어야 합니다. 아이디는 영어 소문자와 숫자만 사용하여 4~20자리입니다", example = "doldol1234")
+	String id,
+	@NotBlank(message = "비밀번호는 필수 입력값입니다.")
+	@Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,16}$",
+		message = "비밀번호는 8~16자리로 영문 대소문자, 숫자, 특수문자를 포함해야 합니다.")
+	@Schema(description = "비밀번호는 입력되어야 합니다. 비밀번호는 8~16자리 수 입니다. 영문 대소문자, 숫자, 특수문자를 포함합니다.", example = "doldol1234!")
+	String password,
+	@NotBlank(message = "비밀번호 확인은 필수 입력값입니다.")
+	@Schema(description = "위의 비밀번호 항목과 동일해야 합니다.", example = "doldol1234!")
+	String passwordConfirm,
+	@NotBlank(message = "이름은 필수 입력값입니다.")
+	@Schema(description = "이름", example = "김돌돌")
+	String name,
+	@NotBlank(message = "휴대전화 번호는 필수 입력값입니다.")
+	@Pattern(regexp = "^010\\d{8}$", message = "전화번호는 010으로 시작하는 11자리 숫자여야 합니다.")
+	@Schema(description = "휴대전화 번호", example = "01012341234")
+	String phone,
+	@NotBlank(message = "이메일은 필수 입력값입니다.")
+	@Email(message = "올바른 이메일 양식을 입력해주세요.")
+	@Schema(description = "이메일", example = "doldol@test.com")
+	String email,
+	@AssertTrue(message = "이용약관에 동의해야 합니다.")
+	@Schema(description = "이용약관 동의", example = "true")
+	boolean termsAgreed,
+	@AssertTrue(message = "개인정보 수집에 동의해야 합니다.")
+	@Schema(description = "개인정보 수집 동의", example = "true")
+	boolean privacyAgreed,
+	@AssertTrue(message = "만 14세 이상이어야 합니다.")
+	@Schema(description = "만 14세 이상 여부", example = "true")
+	boolean ageOverFourteen
+) {
+}

--- a/src/main/java/doldol_server/doldol/auth/dto/request/TempJoinRequest.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/request/TempJoinRequest.java
@@ -11,31 +11,40 @@ public record TempJoinRequest(
 	@Pattern(regexp = "^[a-z0-9]{4,20}$", message = "아이디는 영어 소문자와 숫자만 사용하여 4~20자리여야 합니다.")
 	@Schema(description = "아이디는 입력되어야 합니다. 아이디는 영어 소문자와 숫자만 사용하여 4~20자리입니다", example = "doldol1234")
 	String id,
+
 	@NotBlank(message = "비밀번호는 필수 입력값입니다.")
 	@Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,16}$",
 		message = "비밀번호는 8~16자리로 영문 대소문자, 숫자, 특수문자를 포함해야 합니다.")
 	@Schema(description = "비밀번호는 입력되어야 합니다. 비밀번호는 8~16자리 수 입니다. 영문 대소문자, 숫자, 특수문자를 포함합니다.", example = "doldol1234!")
 	String password,
+
 	@NotBlank(message = "비밀번호 확인은 필수 입력값입니다.")
 	@Schema(description = "위의 비밀번호 항목과 동일해야 합니다.", example = "doldol1234!")
 	String passwordConfirm,
+
 	@NotBlank(message = "이름은 필수 입력값입니다.")
+	@Pattern(regexp = "^[가-힣]{1,5}$", message = "이름은 한글 1~5글자만 입력 가능합니다.")
 	@Schema(description = "이름", example = "김돌돌")
 	String name,
+
 	@NotBlank(message = "휴대전화 번호는 필수 입력값입니다.")
 	@Pattern(regexp = "^010\\d{8}$", message = "전화번호는 010으로 시작하는 11자리 숫자여야 합니다.")
 	@Schema(description = "휴대전화 번호", example = "01012341234")
 	String phone,
+
 	@NotBlank(message = "이메일은 필수 입력값입니다.")
 	@Email(message = "올바른 이메일 양식을 입력해주세요.")
 	@Schema(description = "이메일", example = "doldol@test.com")
 	String email,
+
 	@AssertTrue(message = "이용약관에 동의해야 합니다.")
 	@Schema(description = "이용약관 동의", example = "true")
 	boolean termsAgreed,
+
 	@AssertTrue(message = "개인정보 수집에 동의해야 합니다.")
 	@Schema(description = "개인정보 수집 동의", example = "true")
 	boolean privacyAgreed,
+
 	@AssertTrue(message = "만 14세 이상이어야 합니다.")
 	@Schema(description = "만 14세 이상 여부", example = "true")
 	boolean ageOverFourteen

--- a/src/main/java/doldol_server/doldol/auth/dto/response/TempSignupResponse.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/response/TempSignupResponse.java
@@ -1,0 +1,48 @@
+package doldol_server.doldol.auth.dto.response;
+
+import doldol_server.doldol.auth.dto.request.TempJoinRequest;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TempSignupResponse {
+
+	private String email;
+	private String loginId;
+	private String password;
+	private String name;
+	private String phoneNumber;
+	private String verificationCode;
+	private boolean verified = false;
+
+	public static TempSignupResponse getTempSignupDate(TempJoinRequest tempJoinRequest) {
+		return TempSignupResponse.builder()
+			.email(tempJoinRequest.email())
+			.name(tempJoinRequest.name())
+			.loginId(tempJoinRequest.id())
+			.phoneNumber(tempJoinRequest.phone())
+			.password(tempJoinRequest.password())
+			.build();
+	}
+
+	public void initVerificationCode(String verificationCode) {
+		this.verificationCode = verificationCode;
+	}
+
+	public void updateVerificationStatus() {
+		this.verified = true;
+	}
+
+	@Builder
+	private TempSignupResponse(String email, String loginId, String name, String password, String phoneNumber,
+		String verificationCode) {
+		this.email = email;
+		this.loginId = loginId;
+		this.name = name;
+		this.password = password;
+		this.phoneNumber = phoneNumber;
+		this.verificationCode = verificationCode;
+	}
+}

--- a/src/main/java/doldol_server/doldol/auth/service/AuthService.java
+++ b/src/main/java/doldol_server/doldol/auth/service/AuthService.java
@@ -35,6 +35,7 @@ public class AuthService {
 		}
 	}
 
+	@Transactional
 	public void tempJoin(@Valid TempJoinRequest tempJoinRequest) {
 
 		boolean isEmailExists = userRepository.existsByEmail(tempJoinRequest.email());
@@ -53,6 +54,7 @@ public class AuthService {
 		redisTemplate.opsForValue().set(tempJoinRequest.email(), tempSignupResponse, 10, TimeUnit.MINUTES);
 	}
 
+	@Transactional
 	public void sendVerificationCode(String email) {
 		TempSignupResponse tempSignupResponse = (TempSignupResponse)redisTemplate.opsForValue().get(email);
 
@@ -68,6 +70,7 @@ public class AuthService {
 		emailService.sendEmailVerificationCode(email, verificationCode);
 	}
 
+	@Transactional
 	public void validateVerificationCode(String email, String code) {
 		TempSignupResponse tempSignupResponse = (TempSignupResponse)redisTemplate.opsForValue().get(email);
 

--- a/src/main/java/doldol_server/doldol/auth/service/AuthService.java
+++ b/src/main/java/doldol_server/doldol/auth/service/AuthService.java
@@ -1,0 +1,110 @@
+package doldol_server.doldol.auth.service;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import doldol_server.doldol.auth.dto.request.TempJoinRequest;
+import doldol_server.doldol.auth.dto.response.TempSignupResponse;
+import doldol_server.doldol.auth.util.GeneratorRandomUtil;
+import doldol_server.doldol.common.exception.AuthErrorCode;
+import doldol_server.doldol.common.exception.CustomException;
+import doldol_server.doldol.user.entity.User;
+import doldol_server.doldol.user.repository.UserRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final EmailService emailService;
+	private final UserRepository userRepository;
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final PasswordEncoder passwordEncoder;
+
+	public void checkIdDuplicate(String id) {
+		boolean isIdExists = userRepository.existsByLoginId(id);
+
+		if (isIdExists) {
+			throw new CustomException(AuthErrorCode.ID_DUPLICATED);
+		}
+	}
+
+	public void tempJoin(@Valid TempJoinRequest tempJoinRequest) {
+
+		boolean isEmailExists = userRepository.existsByEmail(tempJoinRequest.email());
+
+		if (isEmailExists) {
+			throw new CustomException(AuthErrorCode.EMAIl_DUPLICATED);
+		}
+
+		boolean isPhoneNumberExists = userRepository.existsByPhoneNumber(tempJoinRequest.phone());
+
+		if (isPhoneNumberExists) {
+			throw new CustomException(AuthErrorCode.PHONE_NUMBER_DUPLICATED);
+		}
+
+		TempSignupResponse tempSignupResponse = TempSignupResponse.getTempSignupDate(tempJoinRequest);
+		redisTemplate.opsForValue().set(tempJoinRequest.email(), tempSignupResponse, 10, TimeUnit.MINUTES);
+	}
+
+	public void sendVerificationCode(String email) {
+		TempSignupResponse tempSignupResponse = (TempSignupResponse)redisTemplate.opsForValue().get(email);
+
+		if (tempSignupResponse == null) {
+			throw new CustomException(AuthErrorCode.EMAIL_NOT_FOUND);
+		}
+
+		String verificationCode = GeneratorRandomUtil.generateRandomNum();
+
+		tempSignupResponse.initVerificationCode(verificationCode);
+		redisTemplate.opsForValue().set(email, tempSignupResponse, 5, TimeUnit.MINUTES);
+
+		emailService.sendEmailVerificationCode(email, verificationCode);
+	}
+
+	public void validateVerificationCode(String email, String code) {
+		TempSignupResponse tempSignupResponse = (TempSignupResponse)redisTemplate.opsForValue().get(email);
+
+		if (tempSignupResponse == null) {
+			throw new CustomException(AuthErrorCode.EMAIL_NOT_FOUND);
+		}
+
+		if (!tempSignupResponse.getVerificationCode().equals(code)) {
+			throw new CustomException(AuthErrorCode.VERIFICATION_CODE_WRONG);
+		}
+
+		tempSignupResponse.updateVerificationStatus();
+		redisTemplate.opsForValue().set(email, tempSignupResponse, 30, TimeUnit.MINUTES);
+	}
+
+	@Transactional
+	public void join(String email) {
+		TempSignupResponse tempSignupResponse = (TempSignupResponse)redisTemplate.opsForValue().get(email);
+
+		if (tempSignupResponse == null) {
+			throw new CustomException(AuthErrorCode.EMAIL_NOT_FOUND);
+		}
+
+		if (!tempSignupResponse.isVerified()) {
+			throw new CustomException(AuthErrorCode.UNVERIFIED_EMAIL);
+		}
+
+		redisTemplate.delete(email);
+
+		User user = User.builder()
+			.loginId(tempSignupResponse.getLoginId())
+			.password(passwordEncoder.encode(tempSignupResponse.getPassword()))
+			.email(email)
+			.name(tempSignupResponse.getName())
+			.phoneNumber(tempSignupResponse.getPhoneNumber())
+			.build();
+
+		userRepository.save(user);
+	}
+}

--- a/src/main/java/doldol_server/doldol/auth/service/EmailService.java
+++ b/src/main/java/doldol_server/doldol/auth/service/EmailService.java
@@ -1,0 +1,53 @@
+package doldol_server.doldol.auth.service;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import doldol_server.doldol.common.exception.CustomException;
+import doldol_server.doldol.common.exception.MailErrorCode;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+	private final JavaMailSender emailSender;
+	private final SpringTemplateEngine templateEngine;
+	private final RedisTemplate<String, String> redisTemplate;
+
+	@Async
+	public void sendEmailVerificationCode(String email, String verificationCode) {
+		if (!StringUtils.hasText(verificationCode)) {
+			throw new CustomException(MailErrorCode.MISSING_EMAIL);
+		}
+		try {
+			sendToEmail(email, verificationCode);
+		} catch (MessagingException e) {
+			throw new CustomException(MailErrorCode.EMAIL_SENDING_ERROR);
+		}
+	}
+
+	private void sendToEmail(String to, String verificationCode) throws MessagingException {
+		MimeMessage message = emailSender.createMimeMessage();
+		MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+		helper.setTo(to);
+		helper.setSubject("인증 코드 안내");
+
+		Context context = new Context();
+		context.setVariable("code", verificationCode);
+
+		String htmlContent = templateEngine.process("mail", context);
+		helper.setText(htmlContent, true);
+
+		emailSender.send(message);
+	}
+}

--- a/src/main/java/doldol_server/doldol/common/config/AsyncConfig.java
+++ b/src/main/java/doldol_server/doldol/common/config/AsyncConfig.java
@@ -1,0 +1,32 @@
+package doldol_server.doldol.common.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    @Bean(name = "mailExecutor")
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("Async-MailExecutor-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return AsyncConfigurer.super.getAsyncUncaughtExceptionHandler();
+    }
+}

--- a/src/main/java/doldol_server/doldol/common/config/EmailConfig.java
+++ b/src/main/java/doldol_server/doldol/common/config/EmailConfig.java
@@ -1,0 +1,68 @@
+package doldol_server.doldol.common.config;
+
+import java.util.Properties;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.writetimeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.writetimeout", writeTimeout);
+
+        return properties;
+    }
+}

--- a/src/main/java/doldol_server/doldol/common/config/RedisConfig.java
+++ b/src/main/java/doldol_server/doldol/common/config/RedisConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -29,5 +30,16 @@ public class RedisConfig {
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.setValueSerializer(new StringRedisSerializer());
 		return redisTemplate;
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisObjectTemplate() {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(redisConnectionFactory());
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+		template.setHashKeySerializer(new StringRedisSerializer());
+		template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+		return template;
 	}
 }

--- a/src/main/java/doldol_server/doldol/common/exception/AuthErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/AuthErrorCode.java
@@ -8,15 +8,28 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
 
+    // 400
+    VERIFICATION_CODE_WRONG(HttpStatus.BAD_REQUEST, "A-009", "인증번호가 틀렸습니다."),
+
     // 401
     WRONG_ID_PW(HttpStatus.UNAUTHORIZED, "A-001", "아이디 혹은 비밀번호가 올바르지 않습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A-002", "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A-003", "만료된 토큰입니다."),
+    UNVERIFIED_EMAIL(HttpStatus.UNAUTHORIZED, "A-010", "이메일 인증을 하셔야합니다."),
 
     // 403
     INCORRECT_CLAIM_TOKEN(HttpStatus.FORBIDDEN, "A-004", "잘못된 토큰입니다."),
-    USER_NOT_FOUND(HttpStatus.FORBIDDEN, "A-005", "회원을 찾을 수 없습니다."),
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "A-006", "접근이 거부되었습니다.");
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "A-005", "접근이 거부되었습니다."),
+
+    // 404
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "A-006", "회원을 찾을 수 없습니다."),
+    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "A-008", "입력하신 이메일을 찾을 수 없습니다."),
+
+    // 409
+    ID_DUPLICATED(HttpStatus.CONFLICT,"A-007","이미 사용중인 아이디입니다."),
+    EMAIl_DUPLICATED(HttpStatus.CONFLICT,"A-011","이미 사용중인 이메일입니다."),
+    PHONE_NUMBER_DUPLICATED(HttpStatus.CONFLICT,"A-012","이미 사용중인 전화번호입니다."),
+    ;
 
     private HttpStatus httpStatus;
     private String code;

--- a/src/main/java/doldol_server/doldol/common/exception/CustomException.java
+++ b/src/main/java/doldol_server/doldol/common/exception/CustomException.java
@@ -11,7 +11,7 @@ public class CustomException extends RuntimeException{
 		this.errorCode = errorCode;
 	}
 
-	protected CustomException(ErrorCode errorCode) {
+	public CustomException(ErrorCode errorCode) {
 		super(errorCode.getMessage());
 		this.errorCode = errorCode;
 	}

--- a/src/main/java/doldol_server/doldol/common/exception/MailErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/MailErrorCode.java
@@ -1,0 +1,22 @@
+package doldol_server.doldol.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MailErrorCode implements ErrorCode {
+
+	//400 BAD_REQUEST
+	MISSING_EMAIL(HttpStatus.BAD_REQUEST, "M-001", "이메일 주소가 누락되었습니다."),
+
+	//500 INTERNAL_SERVER_ERROR
+	EMAIL_SENDING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "M-002", "이메일 발송에 실패했습니다."),
+	;
+
+	private HttpStatus httpStatus;
+	private String code;
+	private String message;
+}

--- a/src/main/resources/templates/mail.html
+++ b/src/main/resources/templates/mail.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<div style="margin:120px">
+    <div style="margin-bottom: 10px">
+        <h1>인증 코드 메일입니다.</h1>
+        <br/>
+        <h3 style="text-align: center;"> 아래 코드를 사이트에 입력해주십시오</h3>
+    </div>
+    <div style="text-align: center;">
+        <h2 style="color: crimson;" th:text="${code}"></h2>
+    </div>
+    <br/>
+</div>
+</body>
+</html>

--- a/src/test/java/doldol_server/doldol/auth/controller/AuthControllerTest.java
+++ b/src/test/java/doldol_server/doldol/auth/controller/AuthControllerTest.java
@@ -1,0 +1,290 @@
+package doldol_server.doldol.auth.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import doldol_server.doldol.auth.dto.request.EmailCodeSendRequest;
+import doldol_server.doldol.auth.dto.request.EmailCodeVerifyRequest;
+import doldol_server.doldol.auth.dto.request.FinalJoinRequest;
+import doldol_server.doldol.auth.dto.request.TempJoinRequest;
+import doldol_server.doldol.auth.service.AuthService;
+import doldol_server.doldol.common.ControllerTest;
+
+@WebMvcTest(controllers = AuthController.class)
+class AuthControllerTest extends ControllerTest {
+
+	@MockitoBean
+	private AuthService authService;
+
+	@Test
+	@DisplayName("임시 회원가입 - 아이디의 길이가 3 이하이면 오류를 발생시킵니다.")
+	void tempJoin_ValidationFail_IdTooShort() throws Exception {
+		// given
+		TempJoinRequest request = new TempJoinRequest(
+			"tes",
+			"Password123!",
+			"Password123!",
+			"김돌돌",
+			"01012341234",
+			"test@example.com",
+			true,
+			true,
+			true
+		);
+
+		// when & then
+		mockMvc.perform(post("/auth/temp-join")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request)))
+			.andExpect(status().isBadRequest());
+
+		verify(authService, never()).tempJoin(any(TempJoinRequest.class));
+	}
+
+	@Test
+	@DisplayName("임시 회원가입 - 아이디의 길이가 21 이상이면 오류를 발생시킵니다.")
+	void tempJoin_ValidationFail_IdTooLong() throws Exception {
+		// given
+		TempJoinRequest request = new TempJoinRequest(
+			"a".repeat(21),
+			"Password123!",
+			"Password123!",
+			"김돌돌",
+			"01012341234",
+			"test@example.com",
+			true,
+			true,
+			true
+		);
+
+		// when & then
+		mockMvc.perform(post("/auth/temp-join")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request)))
+			.andExpect(status().isBadRequest());
+
+		verify(authService, never()).tempJoin(any(TempJoinRequest.class));
+	}
+
+	@Test
+	@DisplayName("임시 회원가입 - 비밀번호 패턴 불일치면 오류를 발생시킵니다.")
+	void tempJoin_ValidationFail_InvalidPassword() throws Exception {
+		// given
+		TempJoinRequest request = new TempJoinRequest(
+			"testuser123",
+			"weakpass",
+			"weakpass",
+			"김돌돌",
+			"01012341234",
+			"test@example.com",
+			true,
+			true,
+			true
+		);
+
+		// when & then
+		mockMvc.perform(post("/auth/temp-join")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request)))
+			.andExpect(status().isBadRequest());
+
+		verify(authService, never()).tempJoin(any(TempJoinRequest.class));
+	}
+
+	@Test
+	@DisplayName("임시 회원가입 - 잘못된 이메일 형식이면 오류를 발생시킵니다.")
+	void tempJoin_ValidationFail_InvalidEmail() throws Exception {
+		// given
+		TempJoinRequest request = new TempJoinRequest(
+			"testuser123",
+			"Password123!",
+			"Password123!",
+			"김돌돌",
+			"01012341234",
+			"email.com",
+			true,
+			true,
+			true
+		);
+
+		// when & then
+		mockMvc.perform(post("/auth/temp-join")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request)))
+			.andExpect(status().isBadRequest());
+
+		verify(authService, never()).tempJoin(any(TempJoinRequest.class));
+	}
+
+	@Test
+	@DisplayName("임시 회원가입 - 잘못된 전화번호 형식이면 오류를 발생시킵니다.")
+	void tempJoin_ValidationFail_InvalidPhoneNumber() throws Exception {
+		// given
+		TempJoinRequest request = new TempJoinRequest(
+			"testuser123",
+			"Password123!",
+			"Password123!",
+			"김돌돌",
+			"0201234567",
+			"test@example.com",
+			true,
+			true,
+			true
+		);
+
+		// when & then
+		mockMvc.perform(post("/auth/temp-join")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request)))
+			.andExpect(status().isBadRequest());
+
+		verify(authService, never()).tempJoin(any(TempJoinRequest.class));
+	}
+
+	@Test
+	@DisplayName("임시 회원가입 - 이름이 너무 길면 오류를 발생시킵니다.")
+	void tempJoin_ValidationFail_NameTooLong() throws Exception {
+		// given
+		TempJoinRequest request = new TempJoinRequest(
+			"testuser123",
+			"Password123!",
+			"Password123!",
+			"김돌돌돌돌돌",
+			"01012341234",
+			"test@example.com",
+			true,
+			true,
+			true
+		);
+
+		// when & then
+		mockMvc.perform(post("/auth/temp-join")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request)))
+			.andExpect(status().isBadRequest());
+
+		verify(authService, never()).tempJoin(any(TempJoinRequest.class));
+	}
+
+	@Test
+	@DisplayName("임시 회원가입 - 이름이 한글이 아니면 오류를 발생시킵니다.")
+	void tempJoin_ValidationFail_NameNotKorean() throws Exception {
+		// given
+		TempJoinRequest request = new TempJoinRequest(
+			"testuser123",
+			"Password123!",
+			"Password123!",
+			"kimdoldol",
+			"01012341234",
+			"test@example.com",
+			true,
+			true,
+			true
+		);
+
+		// when & then
+		mockMvc.perform(post("/auth/temp-join")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request)))
+			.andExpect(status().isBadRequest());
+
+		verify(authService, never()).tempJoin(any(TempJoinRequest.class));
+	}
+
+	@Test
+	@DisplayName("임시 회원가입 - 약관 동의하지 않으면 오류를 발생시킵니다.")
+	void tempJoin_ValidationFail_TermsNotAgreed() throws Exception {
+		// given
+		TempJoinRequest request = new TempJoinRequest(
+			"testuser123",
+			"Password123!",
+			"Password123!",
+			"김돌돌",
+			"01012341234",
+			"test@example.com",
+			false,
+			true,
+			true
+		);
+
+		// when & then
+		mockMvc.perform(post("/auth/temp-join")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request)))
+			.andExpect(status().isBadRequest());
+
+		verify(authService, never()).tempJoin(any(TempJoinRequest.class));
+	}
+
+	@Test
+	@DisplayName("이메일 인증 코드 전송 - 성공")
+	void sendVerificationCode_Success() throws Exception {
+		// given
+		EmailCodeSendRequest request = new EmailCodeSendRequest("test@example.com");
+		doNothing().when(authService).sendVerificationCode(anyString());
+
+		// when & then
+		mockMvc.perform(post("/auth/email/send-code")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request)))
+			.andExpect(status().isNoContent());
+
+		verify(authService).sendVerificationCode("test@example.com");
+	}
+
+	@Test
+	@DisplayName("이메일 인증 코드 검증 - 성공")
+	void validateVerificationCode_Success() throws Exception {
+		// given
+		EmailCodeVerifyRequest request = new EmailCodeVerifyRequest("test@example.com", "123456");
+		doNothing().when(authService).validateVerificationCode(anyString(), anyString());
+
+		// when & then
+		mockMvc.perform(post("/auth/email/verify-code")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request)))
+			.andExpect(status().isNoContent());
+
+		verify(authService).validateVerificationCode("test@example.com", "123456");
+	}
+
+	@Test
+	@DisplayName("회원가입 완료 - 성공")
+	void join_Success() throws Exception {
+		// given
+		FinalJoinRequest request = new FinalJoinRequest("test@example.com");
+		doNothing().when(authService).join(anyString());
+
+		// when & then
+		mockMvc.perform(post("/auth/join")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request)))
+			.andExpect(status().isNoContent());
+
+		verify(authService).join("test@example.com");
+	}
+
+	@Test
+	@DisplayName("필수 필드 누락 - 400 Bad Request")
+	void tempJoin_ValidationFail_MissingRequiredFields() throws Exception {
+		// given
+		String emptyJson = "{}";
+
+		// when & then
+		mockMvc.perform(post("/auth/temp-join")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(emptyJson))
+			.andExpect(status().isBadRequest());
+
+		verify(authService, never()).tempJoin(any(TempJoinRequest.class));
+	}
+
+}

--- a/src/test/java/doldol_server/doldol/auth/service/AuthServiceTest.java
+++ b/src/test/java/doldol_server/doldol/auth/service/AuthServiceTest.java
@@ -1,0 +1,135 @@
+package doldol_server.doldol.auth.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import doldol_server.doldol.auth.dto.request.TempJoinRequest;
+import doldol_server.doldol.common.ServiceTest;
+import doldol_server.doldol.common.exception.AuthErrorCode;
+import doldol_server.doldol.common.exception.CustomException;
+import doldol_server.doldol.user.repository.UserRepository;
+
+@DisplayName("Auth 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest extends ServiceTest {
+
+	@Autowired
+	private AuthService authService;
+
+	@MockitoBean
+	private UserRepository userRepository;
+
+	@MockitoBean
+	private EmailService emailService;
+
+	@Test
+	@DisplayName("아이디가 중복이면 예외를 발생시킨다")
+	void checkIdDuplicate_ThrowsException_WhenDuplicated() {
+		// given
+		String loginId = "duplicateduser";
+		when(userRepository.existsByLoginId(loginId)).thenReturn(true);
+
+		// when & then
+		CustomException exception = assertThrows(CustomException.class,
+			() -> authService.checkIdDuplicate(loginId));
+
+		assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.ID_DUPLICATED);
+	}
+
+	@Test
+	@DisplayName("임시 회원가입이 성공적으로 처리된다")
+	void tempJoin_Success() {
+		// given
+		TempJoinRequest request = new TempJoinRequest(
+			"test",
+			"test",
+			"test",
+			"test",
+			"01012341234",
+			"test@example.com",
+			true,
+			true,
+			true
+		);
+
+		// when
+		when(userRepository.existsByEmail(request.email())).thenReturn(false);
+		when(userRepository.existsByPhoneNumber(request.phone())).thenReturn(false);
+
+		// then
+		assertDoesNotThrow(() -> authService.tempJoin(request));
+	}
+
+	@Test
+	@DisplayName("이메일이 중복되면 임시 회원가입 시 예외를 발생시킨다")
+	void tempJoin_ThrowsException_WhenEmailDuplicated() {
+		// given
+		TempJoinRequest request = new TempJoinRequest(
+			"test",
+			"test",
+			"test",
+			"test",
+			"01012341234",
+			"test@example.com",
+			true,
+			true,
+			true
+		);
+
+		when(userRepository.existsByEmail(request.email())).thenReturn(true);
+
+		// when & then
+		CustomException exception = assertThrows(CustomException.class,
+			() -> authService.tempJoin(request));
+
+		assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.EMAIl_DUPLICATED);
+	}
+
+	@Test
+	@DisplayName("전화번호가 중복되면 임시 회원가입 시 예외를 발생시킨다")
+	void tempJoin_ThrowsException_WhenPhoneNumberDuplicated() {
+		// given
+		TempJoinRequest request = new TempJoinRequest(
+			"test",
+			"test",
+			"test",
+			"test",
+			"01012341234",
+			"test@example.com",
+			true,
+			true,
+			true
+		);
+
+		when(userRepository.existsByEmail(request.email())).thenReturn(false);
+		when(userRepository.existsByPhoneNumber(request.phone())).thenReturn(true);
+
+		// when & then
+		CustomException exception = assertThrows(CustomException.class,
+			() -> authService.tempJoin(request));
+
+		assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.PHONE_NUMBER_DUPLICATED);
+	}
+
+	@Test
+	@DisplayName("인증 코드 전송 시 이메일이 존재하지 않으면 예외를 발생시킨다")
+	void sendVerificationCode_ThrowsException_WhenEmailNotFound() {
+		// given
+		String email = "notfound@example.com";
+
+		// when & then
+		CustomException exception = assertThrows(CustomException.class,
+			() -> authService.sendVerificationCode(email));
+
+		assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.EMAIL_NOT_FOUND);
+	}
+
+}

--- a/src/test/java/doldol_server/doldol/auth/service/AuthServiceTest.java
+++ b/src/test/java/doldol_server/doldol/auth/service/AuthServiceTest.java
@@ -9,9 +9,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import doldol_server.doldol.auth.dto.request.TempJoinRequest;
+import doldol_server.doldol.auth.dto.response.TempSignupResponse;
 import doldol_server.doldol.common.ServiceTest;
 import doldol_server.doldol.common.exception.AuthErrorCode;
 import doldol_server.doldol.common.exception.CustomException;
@@ -29,6 +32,12 @@ class AuthServiceTest extends ServiceTest {
 
 	@MockitoBean
 	private EmailService emailService;
+
+	@MockitoBean
+	private RedisTemplate<String, Object> redisTemplate;
+
+	@MockitoBean
+	private ValueOperations<String, Object> valueOperations;
 
 	@Test
 	@DisplayName("아이디가 중복이면 예외를 발생시킨다")
@@ -60,12 +69,17 @@ class AuthServiceTest extends ServiceTest {
 			true
 		);
 
+		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+		doNothing().when(valueOperations).set(eq(request.email()), any(TempSignupResponse.class), anyLong(), any());
+
 		// when
 		when(userRepository.existsByEmail(request.email())).thenReturn(false);
 		when(userRepository.existsByPhoneNumber(request.phone())).thenReturn(false);
 
 		// then
 		assertDoesNotThrow(() -> authService.tempJoin(request));
+
+		verify(valueOperations).set(eq(request.email()), any(TempSignupResponse.class), anyLong(), any());
 	}
 
 	@Test
@@ -120,10 +134,13 @@ class AuthServiceTest extends ServiceTest {
 	}
 
 	@Test
-	@DisplayName("인증 코드 전송 시 이메일이 존재하지 않으면 예외를 발생시킨다")
+	@DisplayName("인증 코드 전송 시 임시 가입 정보가 존재하지 않으면 예외를 발생시킨다")
 	void sendVerificationCode_ThrowsException_WhenEmailNotFound() {
 		// given
 		String email = "notfound@example.com";
+
+		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+		when(valueOperations.get(email)).thenReturn(null);
 
 		// when & then
 		CustomException exception = assertThrows(CustomException.class,
@@ -132,4 +149,113 @@ class AuthServiceTest extends ServiceTest {
 		assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.EMAIL_NOT_FOUND);
 	}
 
+	@Test
+	@DisplayName("인증 코드 전송이 성공적으로 처리된다")
+	void sendVerificationCode_Success() {
+		// given
+		String email = "test@example.com";
+		TempSignupResponse tempSignupResponse = TempSignupResponse.getTempSignupDate(
+			new TempJoinRequest("testId", "password", "name", "nickname", "01012341234", email, true, true, true)
+		);
+
+		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+		when(valueOperations.get(email)).thenReturn(tempSignupResponse);
+		doNothing().when(valueOperations).set(eq(email), any(TempSignupResponse.class), anyLong(), any());
+		doNothing().when(emailService).sendEmailVerificationCode(eq(email), anyString());
+
+		// when & then
+		assertDoesNotThrow(() -> authService.sendVerificationCode(email));
+
+		verify(emailService).sendEmailVerificationCode(eq(email), anyString());
+		verify(valueOperations).set(eq(email), any(TempSignupResponse.class), anyLong(), any());
+	}
+
+	@Test
+	@DisplayName("인증 코드 검증이 성공적으로 처리된다")
+	void validateVerificationCode_Success() {
+		// given
+		String email = "test@example.com";
+		String verificationCode = "123456";
+
+		TempSignupResponse tempSignupResponse = TempSignupResponse.getTempSignupDate(
+			new TempJoinRequest("testId", "password", "name", "nickname", "01012341234", email, true, true, true)
+		);
+		tempSignupResponse.initVerificationCode(verificationCode);
+
+		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+		when(valueOperations.get(email)).thenReturn(tempSignupResponse);
+		doNothing().when(valueOperations).set(eq(email), any(TempSignupResponse.class), anyLong(), any());
+
+		// when & then
+		assertDoesNotThrow(() -> authService.validateVerificationCode(email, verificationCode));
+
+		verify(valueOperations).set(eq(email), any(TempSignupResponse.class), anyLong(), any());
+	}
+
+	@Test
+	@DisplayName("잘못된 인증 코드로 검증 시 예외를 발생시킨다")
+	void validateVerificationCode_ThrowsException_WhenCodeWrong() {
+		// given
+		String email = "test@example.com";
+		String correctCode = "123456";
+		String wrongCode = "654321";
+
+		TempSignupResponse tempSignupResponse = TempSignupResponse.getTempSignupDate(
+			new TempJoinRequest("testId", "password", "name", "nickname", "01012341234", email, true, true, true)
+		);
+		tempSignupResponse.initVerificationCode(correctCode);
+
+		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+		when(valueOperations.get(email)).thenReturn(tempSignupResponse);
+
+		// when & then
+		CustomException exception = assertThrows(CustomException.class,
+			() -> authService.validateVerificationCode(email, wrongCode));
+
+		assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.VERIFICATION_CODE_WRONG);
+	}
+
+	@Test
+	@DisplayName("본 가입이 성공적으로 처리된다")
+	void join_Success() {
+		// given
+		String email = "test@example.com";
+
+		TempSignupResponse tempSignupResponse = TempSignupResponse.getTempSignupDate(
+			new TempJoinRequest("testId", "password", "name", "nickname", "01012341234", email, true, true, true)
+		);
+		tempSignupResponse.initVerificationCode("123456");
+		tempSignupResponse.updateVerificationStatus();
+
+		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+		when(valueOperations.get(email)).thenReturn(tempSignupResponse);
+		when(redisTemplate.delete(email)).thenReturn(true);
+		when(userRepository.save(any())).thenReturn(null);
+
+		// when & then
+		assertDoesNotThrow(() -> authService.join(email));
+
+		verify(userRepository).save(any());
+		verify(redisTemplate).delete(email);
+	}
+
+	@Test
+	@DisplayName("이메일 인증이 되지 않은 상태로 본 가입 시 예외를 발생시킨다")
+	void join_ThrowsException_WhenEmailNotVerified() {
+		// given
+		String email = "test@example.com";
+
+		TempSignupResponse tempSignupResponse = TempSignupResponse.getTempSignupDate(
+			new TempJoinRequest("testId", "password", "name", "nickname", "01012341234", email, true, true, true)
+		);
+
+		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+		when(valueOperations.get(email)).thenReturn(tempSignupResponse);
+
+		// when & then
+		CustomException exception = assertThrows(CustomException.class,
+			() -> authService.join(email));
+
+		assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.UNVERIFIED_EMAIL);
+	}
 }

--- a/src/test/java/doldol_server/doldol/common/ControllerTest.java
+++ b/src/test/java/doldol_server/doldol/common/ControllerTest.java
@@ -1,0 +1,29 @@
+package doldol_server.doldol.common;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import doldol_server.doldol.common.config.TestSecurityConfig;
+
+@Import(TestSecurityConfig.class)
+@ActiveProfiles("test")
+public abstract class ControllerTest {
+
+	@Autowired
+	protected MockMvc mockMvc;
+
+	@Autowired
+	protected ObjectMapper objectMapper;
+
+	protected String asJsonString(Object obj) {
+		try {
+			return objectMapper.writeValueAsString(obj);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/src/test/java/doldol_server/doldol/common/ServiceTest.java
+++ b/src/test/java/doldol_server/doldol/common/ServiceTest.java
@@ -1,0 +1,12 @@
+package doldol_server.doldol.common;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import jakarta.transaction.Transactional;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+public abstract class ServiceTest {
+}

--- a/src/test/java/doldol_server/doldol/common/config/TestSecurityConfig.java
+++ b/src/test/java/doldol_server/doldol/common/config/TestSecurityConfig.java
@@ -1,0 +1,20 @@
+package doldol_server.doldol.common.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+public class TestSecurityConfig {
+    @Bean
+    @Primary
+    public SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+        return http
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+            .build();
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -32,6 +32,18 @@ spring:
     port: 587
     username: test@example.com
     password: testpassword
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          ssl:
+            trust: smtp.gmail.com
+          connectiontimeout: 1000
+          timeout: 1000
+          writetimeout: 1000
 
   security:
     oauth2:


### PR DESCRIPTION
## 📄 PR 내용

- 자체 서비스 회원가입 과정입니다. 이메일 인증 전까지는 임시 회원가입이므로 해당 데이터를 레디스에 저장해놓았습니다. 이메일 인증을 하면 레디스에 저장한 해당 유저의 인증 여부를 true로 변경하고 가입 완료 버튼을 눌러야만 db에 삽입됩니다. auth controller에서 다양한 @Valid를 이용하여 필드 타입 및 양식에 대해 검증을 하므로 컨트롤러 테스트, 비즈니스 로직을 위한 서비스 테스트로만 구성을 했습니다, 또한 다양한 컨트롤러와 서비스 테스트들을 위해 공통 컨트롤러, 서비스 테스트 클래스도 생성했습니다.

## 📝 수정 상세 내용 

- 자체 회원가입 MVC 추가
- 자체 회원가입 컨트롤러 테스트 추가
- 자체 회원가입 서비스 테스트 추가

## ✅ 체크리스트

- [X] 자체 회원가입 MVC 추가
- [X] 자체 회원가입 컨트롤러 테스트 추가
- [X] T자체 회원가입 서비스 테스트 추가

## 📍 레퍼런스

- X