### PR TITLE
[FEAT] 소셜 회원가입

### DIFF
--- a/src/main/java/doldol_server/doldol/auth/controller/AuthController.java
+++ b/src/main/java/doldol_server/doldol/auth/controller/AuthController.java
@@ -12,6 +12,7 @@ import doldol_server.doldol.auth.dto.request.EmailCodeVerifyRequest;
 import doldol_server.doldol.auth.dto.request.FinalJoinRequest;
 import doldol_server.doldol.auth.dto.request.IdCheckRequest;
 import doldol_server.doldol.auth.dto.request.TempJoinRequest;
+import doldol_server.doldol.auth.dto.request.OAuthTempJoinRequest;
 import doldol_server.doldol.auth.service.AuthService;
 import doldol_server.doldol.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -71,6 +72,15 @@ public class AuthController {
 		description = "회원가입 완료")
 	public ResponseEntity<ApiResponse<Void>> join(@RequestBody @Valid FinalJoinRequest finalJoinRequest) {
 		authService.join(finalJoinRequest.email());
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.noContent());
+	}
+
+	@PostMapping("/oauth/temp-join")
+	@Operation(
+		summary = "임시 소셜 회원가입 API",
+		description = "임시 소셜 회원가입")
+	public ResponseEntity<ApiResponse<Void>> oauthJoin(@RequestBody @Valid OAuthTempJoinRequest OAuthTempJoinRequest) {
+		authService.tempOAuthJoin(OAuthTempJoinRequest);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.noContent());
 	}
 }

--- a/src/main/java/doldol_server/doldol/auth/dto/CustomUserDetails.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/CustomUserDetails.java
@@ -8,7 +8,6 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
-import doldol_server.doldol.user.entity.SocialType;
 import doldol_server.doldol.user.entity.User;
 import lombok.Getter;
 
@@ -41,7 +40,10 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
 
 	@Override
 	public String getUsername() {
-		return user.getLoginId();
+		if (socialId != null) {
+			return socialId;
+		}
+		return user.getEmail();
 	}
 
 	@Override
@@ -76,11 +78,18 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
 
 	@Override
 	public String getName() {
-		return user.getLoginId();
+		if (socialId != null) {
+			return socialId;
+		}
+		return user.getEmail();
 	}
 
 	public Long getUserId() {
 		return user.getId();
+	}
+
+	public String getUserLoginId() {
+		return user.getLoginId();
 	}
 
 	public String getEmail() {

--- a/src/main/java/doldol_server/doldol/auth/dto/CustomUserDetails.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/CustomUserDetails.java
@@ -11,22 +11,44 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import doldol_server.doldol.user.entity.User;
 import lombok.Getter;
 
+@Getter
 public class CustomUserDetails implements UserDetails, OAuth2User {
 
-	@Getter
-	private final User user;
+	private final Long userId;
+	private final String email;
+	private final String loginId;
+	private final String password;
+	private final String role;
+
 	private final Map<String, Object> attributes;
-	@Getter
 	private final String socialId;
 
 	public CustomUserDetails(User user) {
-		this.user = user;
+		this.userId = user.getId();
+		this.email = user.getEmail();
+		this.loginId = user.getLoginId();
+		this.password = user.getPassword();
+		this.role = user.getRole().name();
 		this.attributes = null;
 		this.socialId = null;
 	}
 
-	public CustomUserDetails(User user, Map<String, Object> attributes, String socialId) {
-		this.user = user;
+	public CustomUserDetails(Long userId, Map<String, Object> attributes, String socialId) {
+		this.userId = userId;
+		this.email = null;
+		this.loginId = null;
+		this.password = null;
+		this.role = null;
+		this.attributes = attributes;
+		this.socialId = socialId;
+	}
+
+	public CustomUserDetails(Map<String, Object> attributes, String socialId) {
+		this.userId = null;
+		this.email = null;
+		this.loginId = null;
+		this.password = null;
+		this.role = null;
 		this.attributes = attributes;
 		this.socialId = socialId;
 	}
@@ -34,55 +56,28 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
 		Collection<GrantedAuthority> authorities = new ArrayList<>();
-		authorities.add(() -> user.getRole().name());
+		authorities.add(() -> role);
 		return authorities;
 	}
 
 	@Override
 	public String getUsername() {
-		return user.getEmail();
+		if (userId == null) {
+			return socialId;
+		}
+		return userId.toString();
 	}
 
 	@Override
 	public String getPassword() {
-		return user.getPassword();
-	}
-
-	@Override
-	public boolean isAccountNonExpired() {
-		return true;
-	}
-
-	@Override
-	public boolean isAccountNonLocked() {
-		return true;
-	}
-
-	@Override
-	public boolean isCredentialsNonExpired() {
-		return true;
-	}
-
-	@Override
-	public boolean isEnabled() {
-		return true;
-	}
-
-	@Override
-	public Map<String, Object> getAttributes() {
-		return attributes != null ? attributes : Map.of();
+		return password;
 	}
 
 	@Override
 	public String getName() {
-		return user.getEmail();
-	}
-
-	public Long getUserId() {
-		return user.getId();
-	}
-
-	public String getUserLoginId() {
-		return user.getLoginId();
+		if (userId == null) {
+			return socialId;
+		}
+		return userId.toString();
 	}
 }

--- a/src/main/java/doldol_server/doldol/auth/dto/CustomUserDetails.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/CustomUserDetails.java
@@ -8,6 +8,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+import doldol_server.doldol.user.entity.SocialType;
 import doldol_server.doldol.user.entity.User;
 import lombok.Getter;
 
@@ -18,17 +19,21 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
 	private final Map<String, Object> attributes;
 	@Getter
 	private final String socialId;
+	@Getter
+	private final SocialType socialType;
 
 	public CustomUserDetails(User user) {
 		this.user = user;
 		this.attributes = null;
 		this.socialId = null;
+		this.socialType = null;
 	}
 
-	public CustomUserDetails(User user, Map<String, Object> attributes, String socialId) {
+	public CustomUserDetails(User user, Map<String, Object> attributes, String socialId, SocialType socialType) {
 		this.user = user;
 		this.attributes = attributes;
 		this.socialId = socialId;
+		this.socialType = socialType;
 	}
 
 	@Override

--- a/src/main/java/doldol_server/doldol/auth/dto/CustomUserDetails.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/CustomUserDetails.java
@@ -16,15 +16,19 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
 	@Getter
 	private final User user;
 	private final Map<String, Object> attributes;
+	@Getter
+	private final String socialId;
 
 	public CustomUserDetails(User user) {
 		this.user = user;
 		this.attributes = null;
+		this.socialId = null;
 	}
 
-	public CustomUserDetails(User user, Map<String, Object> attributes) {
+	public CustomUserDetails(User user, Map<String, Object> attributes, String socialId) {
 		this.user = user;
 		this.attributes = attributes;
+		this.socialId = socialId;
 	}
 
 	@Override

--- a/src/main/java/doldol_server/doldol/auth/dto/CustomUserDetails.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/CustomUserDetails.java
@@ -19,21 +19,17 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
 	private final Map<String, Object> attributes;
 	@Getter
 	private final String socialId;
-	@Getter
-	private final SocialType socialType;
 
 	public CustomUserDetails(User user) {
 		this.user = user;
 		this.attributes = null;
 		this.socialId = null;
-		this.socialType = null;
 	}
 
-	public CustomUserDetails(User user, Map<String, Object> attributes, String socialId, SocialType socialType) {
+	public CustomUserDetails(User user, Map<String, Object> attributes, String socialId) {
 		this.user = user;
 		this.attributes = attributes;
 		this.socialId = socialId;
-		this.socialType = socialType;
 	}
 
 	@Override

--- a/src/main/java/doldol_server/doldol/auth/dto/CustomUserDetails.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/CustomUserDetails.java
@@ -40,9 +40,6 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
 
 	@Override
 	public String getUsername() {
-		if (socialId != null) {
-			return socialId;
-		}
 		return user.getEmail();
 	}
 
@@ -78,9 +75,6 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
 
 	@Override
 	public String getName() {
-		if (socialId != null) {
-			return socialId;
-		}
 		return user.getEmail();
 	}
 
@@ -90,9 +84,5 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
 
 	public String getUserLoginId() {
 		return user.getLoginId();
-	}
-
-	public String getEmail() {
-		return user.getEmail();
 	}
 }

--- a/src/main/java/doldol_server/doldol/auth/dto/OAuth2Response.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/OAuth2Response.java
@@ -1,12 +1,9 @@
 package doldol_server.doldol.auth.dto;
 
-import doldol_server.doldol.user.entity.SocialType;
-
 public interface OAuth2Response {
 
 	String getSocialId();
 
 	String getEmail();
 
-	SocialType getSocialType();
 }

--- a/src/main/java/doldol_server/doldol/auth/dto/OAuth2Response.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/OAuth2Response.java
@@ -1,8 +1,12 @@
 package doldol_server.doldol.auth.dto;
 
+import doldol_server.doldol.user.entity.SocialType;
+
 public interface OAuth2Response {
 
-	String getProviderId();
+	String getSocialId();
 
 	String getEmail();
+
+	SocialType getSocialType();
 }

--- a/src/main/java/doldol_server/doldol/auth/dto/kakao/KakaoResponse.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/kakao/KakaoResponse.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import doldol_server.doldol.auth.dto.OAuth2Response;
+import doldol_server.doldol.user.entity.SocialType;
 
 public class KakaoResponse implements OAuth2Response {
 
@@ -24,12 +25,17 @@ public class KakaoResponse implements OAuth2Response {
 	}
 
 	@Override
-	public String getProviderId() {
+	public String getSocialId() {
 		return providerId;
 	}
 
 	@Override
 	public String getEmail() {
 		return email;
+	}
+
+	@Override
+	public SocialType getSocialType() {
+		return SocialType.KAKAO;
 	}
 }

--- a/src/main/java/doldol_server/doldol/auth/dto/kakao/KakaoResponse.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/kakao/KakaoResponse.java
@@ -33,9 +33,4 @@ public class KakaoResponse implements OAuth2Response {
 	public String getEmail() {
 		return email;
 	}
-
-	@Override
-	public SocialType getSocialType() {
-		return SocialType.KAKAO;
-	}
 }

--- a/src/main/java/doldol_server/doldol/auth/dto/request/OAuthTempJoinRequest.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/request/OAuthTempJoinRequest.java
@@ -1,0 +1,44 @@
+package doldol_server.doldol.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record OAuthTempJoinRequest(
+	@NotBlank(message = "이름은 필수 입력값입니다.")
+	@Schema(description = "이름", example = "김돌돌")
+	String name,
+
+	@NotBlank(message = "휴대전화 번호는 필수 입력값입니다.")
+	@Pattern(regexp = "^010\\d{8}$", message = "전화번호는 010으로 시작하는 11자리 숫자여야 합니다.")
+	@Schema(description = "휴대전화 번호", example = "01012341234")
+	String phone,
+
+	@NotBlank(message = "이메일은 필수 입력값입니다.")
+	@Email(message = "올바른 이메일 양식을 입력해주세요.")
+	@Schema(description = "이메일", example = "doldol@test.com")
+	String email,
+
+	@AssertTrue(message = "이용약관에 동의해야 합니다.")
+	@Schema(description = "이용약관 동의", example = "true")
+	boolean termsAgreed,
+
+	@AssertTrue(message = "개인정보 수집에 동의해야 합니다.")
+	@Schema(description = "개인정보 수집 동의", example = "true")
+	boolean privacyAgreed,
+
+	@AssertTrue(message = "만 14세 이상이어야 합니다.")
+	@Schema(description = "만 14세 이상 여부", example = "true")
+	boolean ageOverFourteen,
+
+	@NotBlank(message = "소셜 아이디는 필수 입력값입니다.")
+	@Schema(description = "소셜 아이디", example = "1233244124")
+	String socialId,
+
+	@NotBlank(message = "소셜 타입은 필수 입력값입니다.")
+	@Schema(description = "소셜 타입", example = "kakao")
+	String socialType
+) {
+}

--- a/src/main/java/doldol_server/doldol/auth/dto/response/LoginResponse.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/response/LoginResponse.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 @Builder
 @Schema(name = "LoginResponse: 로그인 응답 Dto")
 public record LoginResponse(
+	@Schema(description = "유저 식별 값입니다,", example = "1")
+	Long userId,
 	@Schema(description = "로그인 성공한 유저의 권한입니다.", example = "ADMIN")
 	String role
 ) {}

--- a/src/main/java/doldol_server/doldol/auth/dto/response/OAuthTempSignupResponse.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/response/OAuthTempSignupResponse.java
@@ -1,33 +1,32 @@
 package doldol_server.doldol.auth.dto.response;
 
-import doldol_server.doldol.auth.dto.request.TempJoinRequest;
+import doldol_server.doldol.auth.dto.request.OAuthTempJoinRequest;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class TempSignupResponse implements VerifiableSignupResponse {
+public class OAuthTempSignupResponse implements VerifiableSignupResponse {
 
 	private String email;
-	private String loginId;
-	private String password;
 	private String name;
 	private String phoneNumber;
+	private String socialId;
+	private String socialType;
 	private String verificationCode;
 	private boolean verified = false;
 
-	public static TempSignupResponse getTempSignupDate(TempJoinRequest tempJoinRequest) {
-		return TempSignupResponse.builder()
-			.email(tempJoinRequest.email())
-			.name(tempJoinRequest.name())
-			.loginId(tempJoinRequest.id())
-			.phoneNumber(tempJoinRequest.phone())
-			.password(tempJoinRequest.password())
+	public static OAuthTempSignupResponse getOAuthTempSignupDate(OAuthTempJoinRequest oAuthTempJoinRequest) {
+		return OAuthTempSignupResponse.builder()
+			.email(oAuthTempJoinRequest.email())
+			.name(oAuthTempJoinRequest.name())
+			.phoneNumber(oAuthTempJoinRequest.phone())
+			.socialId(oAuthTempJoinRequest.socialId())
+			.socialType(oAuthTempJoinRequest.socialType())
 			.build();
 	}
 
-	// VerifiableSignupResponse 인터페이스 구현
 	@Override
 	public String getVerificationCode() {
 		return this.verificationCode;
@@ -54,13 +53,13 @@ public class TempSignupResponse implements VerifiableSignupResponse {
 	}
 
 	@Builder
-	private TempSignupResponse(String email, String loginId, String name, String password, String phoneNumber,
+	private OAuthTempSignupResponse(String email, String name, String phoneNumber, String socialId, String socialType,
 		String verificationCode) {
 		this.email = email;
-		this.loginId = loginId;
 		this.name = name;
-		this.password = password;
 		this.phoneNumber = phoneNumber;
+		this.socialId = socialId;
+		this.socialType = socialType;
 		this.verificationCode = verificationCode;
 	}
 }

--- a/src/main/java/doldol_server/doldol/auth/dto/response/VerifiableSignupResponse.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/response/VerifiableSignupResponse.java
@@ -1,0 +1,9 @@
+package doldol_server.doldol.auth.dto.response;
+
+public interface VerifiableSignupResponse {
+    String getVerificationCode();
+    void initVerificationCode(String code);
+    void updateVerificationStatus();
+    boolean isVerified();
+    String getEmail();
+}

--- a/src/main/java/doldol_server/doldol/auth/filter/CustomUserLoginFilter.java
+++ b/src/main/java/doldol_server/doldol/auth/filter/CustomUserLoginFilter.java
@@ -1,34 +1,29 @@
 package doldol_server.doldol.auth.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import doldol_server.doldol.auth.dto.request.LoginRequest;
 import doldol_server.doldol.auth.jwt.TokenProvider;
+import doldol_server.doldol.auth.util.ResponseUtil;
+import doldol_server.doldol.common.exception.AuthErrorCode;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
+
+import java.io.IOException;
 import java.util.Set;
+
 import org.springframework.security.authentication.AuthenticationManager;
 
 public class CustomUserLoginFilter extends CustomUsernamePasswordAuthenticationFilter {
 
-    private static final String LONGIN_URI = "/auth/login";
-    private final Validator validator;
+	private static final String LONGIN_URI = "/auth/login";
 
-    public CustomUserLoginFilter(AuthenticationManager authenticationManager,
-                                 TokenProvider tokenProvider,
-                                 ObjectMapper objectMapper,
-                                 Validator validator) {
-        super(authenticationManager, tokenProvider, objectMapper);
-        this.validator = validator;
-        this.setFilterProcessesUrl(LONGIN_URI);
-    }
+	public CustomUserLoginFilter(AuthenticationManager authenticationManager,
+		TokenProvider tokenProvider,
+		ObjectMapper objectMapper) {
+		super(authenticationManager, tokenProvider, objectMapper);
+		this.setFilterProcessesUrl(LONGIN_URI);
+	}
 
-    @Override
-    protected void validateLoginRequestDto(LoginRequest loginRequest) {
-        Set<ConstraintViolation<LoginRequest>> violations = validator.validate(loginRequest);
-
-        if (!violations.isEmpty()) {
-            String errorMessage = violations.iterator().next().getMessage();
-            throw new IllegalArgumentException(errorMessage);
-        }
-    }
 }

--- a/src/main/java/doldol_server/doldol/auth/filter/CustomUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/doldol_server/doldol/auth/filter/CustomUsernamePasswordAuthenticationFilter.java
@@ -92,6 +92,7 @@ public abstract class CustomUsernamePasswordAuthenticationFilter extends Usernam
 		UserTokenResponse loginToken = tokenProvider.createLoginToken(userid);
 
 		LoginResponse loginResponse = LoginResponse.builder()
+			.userId(userDetails.getUserId())
 			.role(role)
 			.build();
 

--- a/src/main/java/doldol_server/doldol/auth/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/doldol_server/doldol/auth/handler/CustomOAuth2SuccessHandler.java
@@ -27,13 +27,11 @@ import doldol_server.doldol.auth.jwt.TokenProvider;
 import doldol_server.doldol.auth.jwt.dto.UserTokenResponse;
 import doldol_server.doldol.auth.util.CookieUtil;
 import doldol_server.doldol.auth.util.ResponseUtil;
-import doldol_server.doldol.user.entity.User;
+import doldol_server.doldol.user.entity.SocialType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
@@ -59,22 +57,29 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 		OAuth2User oAuth2User = oAuth2Token.getPrincipal();
 
 		CustomUserDetails userDetails = (CustomUserDetails)oAuth2User;
-		User user = userDetails.getUser();
 
-		if (user.getLoginId().startsWith(tempUserPrefix)) {
-			handleNewSocialUser(response, userDetails.getSocialId());
+		if (userDetails.getName().startsWith(tempUserPrefix)) {
+			handleNewSocialUser(response, userDetails.getSocialId(), userDetails.getEmail(),
+				userDetails.getSocialType());
 		} else {
 			handleExistingUser(response, userDetails);
 		}
 	}
 
-	private void handleNewSocialUser(HttpServletResponse response, String socialId) throws IOException {
+	private void handleNewSocialUser(HttpServletResponse response, String socialId, String email,
+		SocialType socialType) throws IOException {
 
 		String encodedSocialId = passwordEncoder.encode(socialId);
+		String encodedEmail = passwordEncoder.encode(email);
+		String encodedSocialType = passwordEncoder.encode(socialType.toString());
 
 		String urlEncodedSocialId = URLEncoder.encode(encodedSocialId, StandardCharsets.UTF_8);
+		String urlEncodedEmail = URLEncoder.encode(encodedEmail, StandardCharsets.UTF_8);
+		String urlEncodedSocialType = URLEncoder.encode(encodedSocialType, StandardCharsets.UTF_8);
 
-		String redirectUrl = signUpRedirectUrl + "?socialId=" + urlEncodedSocialId;
+		String redirectUrl =
+			signUpRedirectUrl + "?socialId=" + urlEncodedSocialId + "?email=" + urlEncodedEmail + "?socialType="
+				+ urlEncodedSocialType;
 
 		Map<String, String> headers = new HashMap<>();
 		headers.put(HttpHeaders.LOCATION, redirectUrl);

--- a/src/main/java/doldol_server/doldol/auth/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/doldol_server/doldol/auth/handler/CustomOAuth2SuccessHandler.java
@@ -37,9 +37,6 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 	private final TokenProvider tokenProvider;
 	private final ObjectMapper objectMapper;
 
-	@Value("${oauth2.temp-user.prefix}")
-	private String tempUserPrefix;
-
 	@Value("${oauth2.redirect-url.sign-up}")
 	private String signUpRedirectUrl;
 
@@ -54,7 +51,7 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 		OAuth2User oAuth2User = oAuth2Token.getPrincipal();
 
 		CustomUserDetails userDetails = (CustomUserDetails)oAuth2User;
-		if (userDetails.getUserLoginId().startsWith(tempUserPrefix)) {
+		if (userDetails.getUserId() == null) {
 			handleNewSocialUser(response, userDetails.getSocialId());
 		} else {
 			handleExistingUser(response, userDetails);

--- a/src/main/java/doldol_server/doldol/auth/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/doldol_server/doldol/auth/handler/CustomOAuth2SuccessHandler.java
@@ -59,27 +59,20 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 		CustomUserDetails userDetails = (CustomUserDetails)oAuth2User;
 
 		if (userDetails.getName().startsWith(tempUserPrefix)) {
-			handleNewSocialUser(response, userDetails.getSocialId(), userDetails.getEmail(),
-				userDetails.getSocialType());
+			handleNewSocialUser(response, userDetails.getSocialId());
 		} else {
 			handleExistingUser(response, userDetails);
 		}
 	}
 
-	private void handleNewSocialUser(HttpServletResponse response, String socialId, String email,
-		SocialType socialType) throws IOException {
+	private void handleNewSocialUser(HttpServletResponse response, String socialId) throws IOException {
 
 		String encodedSocialId = passwordEncoder.encode(socialId);
-		String encodedEmail = passwordEncoder.encode(email);
-		String encodedSocialType = passwordEncoder.encode(socialType.toString());
 
 		String urlEncodedSocialId = URLEncoder.encode(encodedSocialId, StandardCharsets.UTF_8);
-		String urlEncodedEmail = URLEncoder.encode(encodedEmail, StandardCharsets.UTF_8);
-		String urlEncodedSocialType = URLEncoder.encode(encodedSocialType, StandardCharsets.UTF_8);
 
 		String redirectUrl =
-			signUpRedirectUrl + "?socialId=" + urlEncodedSocialId + "?email=" + urlEncodedEmail + "?socialType="
-				+ urlEncodedSocialType;
+			signUpRedirectUrl + "?socialId=" + urlEncodedSocialId;
 
 		Map<String, String> headers = new HashMap<>();
 		headers.put(HttpHeaders.LOCATION, redirectUrl);

--- a/src/main/java/doldol_server/doldol/auth/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/doldol_server/doldol/auth/handler/CustomOAuth2SuccessHandler.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import doldol_server.doldol.auth.dto.CustomUserDetails;
+import doldol_server.doldol.auth.dto.response.LoginResponse;
 import doldol_server.doldol.auth.jwt.TokenProvider;
 import doldol_server.doldol.auth.jwt.dto.UserTokenResponse;
 import doldol_server.doldol.auth.util.CookieUtil;
@@ -82,6 +83,11 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 
 		UserTokenResponse loginToken = tokenProvider.createLoginToken(userid);
 
+		LoginResponse loginResponse = LoginResponse.builder()
+			.userId(userDetails.getUserId())
+			.role(userDetails.getRole())
+			.build();
+
 		ResponseCookie refreshTokenCookie = CookieUtil.createCookie(
 			REFRESH_TOKEN_COOKIE_NAME,
 			loginToken.refreshToken(),
@@ -96,7 +102,7 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 		ResponseUtil.writeSuccessResponseWithHeaders(
 			response,
 			objectMapper,
-			null,
+			loginResponse,
 			HttpStatus.FOUND,
 			headers
 		);

--- a/src/main/java/doldol_server/doldol/auth/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/doldol_server/doldol/auth/handler/CustomOAuth2SuccessHandler.java
@@ -14,7 +14,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -27,7 +26,6 @@ import doldol_server.doldol.auth.jwt.TokenProvider;
 import doldol_server.doldol.auth.jwt.dto.UserTokenResponse;
 import doldol_server.doldol.auth.util.CookieUtil;
 import doldol_server.doldol.auth.util.ResponseUtil;
-import doldol_server.doldol.user.entity.SocialType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -38,7 +36,6 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 
 	private final TokenProvider tokenProvider;
 	private final ObjectMapper objectMapper;
-	private final PasswordEncoder passwordEncoder;
 
 	@Value("${oauth2.temp-user.prefix}")
 	private String tempUserPrefix;
@@ -57,8 +54,7 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 		OAuth2User oAuth2User = oAuth2Token.getPrincipal();
 
 		CustomUserDetails userDetails = (CustomUserDetails)oAuth2User;
-
-		if (userDetails.getName().startsWith(tempUserPrefix)) {
+		if (userDetails.getUserLoginId().startsWith(tempUserPrefix)) {
 			handleNewSocialUser(response, userDetails.getSocialId());
 		} else {
 			handleExistingUser(response, userDetails);
@@ -67,9 +63,7 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 
 	private void handleNewSocialUser(HttpServletResponse response, String socialId) throws IOException {
 
-		String encodedSocialId = passwordEncoder.encode(socialId);
-
-		String urlEncodedSocialId = URLEncoder.encode(encodedSocialId, StandardCharsets.UTF_8);
+		String urlEncodedSocialId = URLEncoder.encode(socialId, StandardCharsets.UTF_8);
 
 		String redirectUrl =
 			signUpRedirectUrl + "?socialId=" + urlEncodedSocialId;

--- a/src/main/java/doldol_server/doldol/auth/jwt/TokenProvider.java
+++ b/src/main/java/doldol_server/doldol/auth/jwt/TokenProvider.java
@@ -65,10 +65,6 @@ public class TokenProvider {
 		return createToken(userId, REFRESH_TOKEN_EXPIRATION_DAYS * DAYS_IN_MILLISECONDS);
 	}
 
-	public String createSocialTempToken(final String userId) {
-		return createToken(userId, TEMP_ACCESS_TOKEN_EXPIRATION_MINUTE * MINUTE_IN_MILLISECONDS);
-	}
-
 	public String resolveAccessToken(HttpServletRequest request) {
 		String requestAccessTokenInHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
 		if (requestAccessTokenInHeader != null && requestAccessTokenInHeader.startsWith(BEARER_FIX)) {

--- a/src/main/java/doldol_server/doldol/auth/service/AuthService.java
+++ b/src/main/java/doldol_server/doldol/auth/service/AuthService.java
@@ -101,11 +101,11 @@ public class AuthService {
 		redisTemplate.delete(email);
 
 		User user = User.builder()
-			.loginId(tempSignupResponse.getLoginId())
+			.loginId(passwordEncoder.encode(tempSignupResponse.getLoginId()))
 			.password(passwordEncoder.encode(tempSignupResponse.getPassword()))
 			.email(email)
 			.name(tempSignupResponse.getName())
-			.phoneNumber(tempSignupResponse.getPhoneNumber())
+			.phoneNumber(passwordEncoder.encode(tempSignupResponse.getPhoneNumber()))
 			.build();
 
 		userRepository.save(user);

--- a/src/main/java/doldol_server/doldol/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/doldol_server/doldol/auth/service/CustomOAuth2UserService.java
@@ -53,13 +53,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 		Optional<User> socialLinkedUser = userRepository.findBySocialId(oAuth2Response.getSocialId());
 		if (socialLinkedUser.isPresent()) {
-			return handleExistingUser(socialLinkedUser.get(), oAuth2User, registrationId);
+			return handleExistingUser(socialLinkedUser.get(), oAuth2User, oAuth2Response.getSocialId());
 		}
 
 		if (isAccountLinking) {
 			return handleAccountLinking(userId, oAuth2Response, oAuth2User, registrationId);
 		} else {
-			return handleNewUser(oAuth2Response, oAuth2User, registrationId);
+			return handleNewUser(oAuth2Response, oAuth2User, oAuth2Response.getSocialId());
 		}
 	}
 
@@ -95,10 +95,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 		existingUser.updateSocialInfo(oAuth2Response.getSocialId(), SocialType.getSocialType(registrationId));
 		User savedUser = userRepository.save(existingUser);
 
-		return new CustomUserDetails(savedUser, oAuth2User.getAttributes(), registrationId);
+		return new CustomUserDetails(savedUser, oAuth2User.getAttributes(), oAuth2Response.getSocialId());
 	}
 
-	private OAuth2User handleNewUser(OAuth2Response oAuth2Response, OAuth2User oAuth2User, String registrationId) {
+	private OAuth2User handleNewUser(OAuth2Response oAuth2Response, OAuth2User oAuth2User, String socialId) {
 
 		User tempUser = User.builder()
 			.loginId(tempUserPrefix + generateRandomString())
@@ -106,7 +106,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 			.socialId(oAuth2Response.getSocialId())
 			.build();
 
-		return new CustomUserDetails(tempUser, oAuth2User.getAttributes(), registrationId);
+		return new CustomUserDetails(tempUser, oAuth2User.getAttributes(), socialId);
 	}
 
 	private void validateUserId(String userId) {

--- a/src/main/java/doldol_server/doldol/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/doldol_server/doldol/auth/service/CustomOAuth2UserService.java
@@ -53,15 +53,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 		Optional<User> socialLinkedUser = userRepository.findBySocialId(oAuth2Response.getSocialId());
 		if (socialLinkedUser.isPresent()) {
-			return handleExistingUser(socialLinkedUser.get(), oAuth2User, registrationId,
-				oAuth2Response.getSocialType());
+			return handleExistingUser(socialLinkedUser.get(), oAuth2User, registrationId);
 		}
 
 		if (isAccountLinking) {
-			return handleAccountLinking(userId, oAuth2Response, oAuth2User, registrationId,
-				oAuth2Response.getSocialType());
+			return handleAccountLinking(userId, oAuth2Response, oAuth2User, registrationId);
 		} else {
-			return handleNewUser(oAuth2Response, oAuth2User, registrationId, oAuth2Response.getSocialType());
+			return handleNewUser(oAuth2Response, oAuth2User, registrationId);
 		}
 	}
 
@@ -82,13 +80,12 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 		return null;
 	}
 
-	private OAuth2User handleExistingUser(User user, OAuth2User oAuth2User, String registrationId,
-		SocialType socialType) {
-		return new CustomUserDetails(user, oAuth2User.getAttributes(), registrationId, socialType);
+	private OAuth2User handleExistingUser(User user, OAuth2User oAuth2User, String registrationId) {
+		return new CustomUserDetails(user, oAuth2User.getAttributes(), registrationId);
 	}
 
 	private OAuth2User handleAccountLinking(String userId, OAuth2Response oAuth2Response,
-		OAuth2User oAuth2User, String registrationId, SocialType socialType) {
+		OAuth2User oAuth2User, String registrationId) {
 
 		validateUserId(userId);
 
@@ -98,20 +95,18 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 		existingUser.updateSocialInfo(oAuth2Response.getSocialId(), SocialType.getSocialType(registrationId));
 		User savedUser = userRepository.save(existingUser);
 
-		return new CustomUserDetails(savedUser, oAuth2User.getAttributes(), registrationId, socialType);
+		return new CustomUserDetails(savedUser, oAuth2User.getAttributes(), registrationId);
 	}
 
-	private OAuth2User handleNewUser(OAuth2Response oAuth2Response, OAuth2User oAuth2User, String registrationId,
-		SocialType socialType) {
+	private OAuth2User handleNewUser(OAuth2Response oAuth2Response, OAuth2User oAuth2User, String registrationId) {
 
 		User tempUser = User.builder()
 			.loginId(tempUserPrefix + generateRandomString())
 			.email(oAuth2Response.getEmail())
 			.socialId(oAuth2Response.getSocialId())
-			.socialType(socialType)
 			.build();
 
-		return new CustomUserDetails(tempUser, oAuth2User.getAttributes(), registrationId, socialType);
+		return new CustomUserDetails(tempUser, oAuth2User.getAttributes(), registrationId);
 	}
 
 	private void validateUserId(String userId) {

--- a/src/main/java/doldol_server/doldol/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/doldol_server/doldol/auth/service/CustomOAuth2UserService.java
@@ -54,7 +54,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 		Optional<User> socialLinkedUser = userRepository.findBySocialId(oAuth2Response.getProviderId());
 		if (socialLinkedUser.isPresent()) {
-			return handleExistingUser(socialLinkedUser.get(), oAuth2User);
+			return handleExistingUser(socialLinkedUser.get(), oAuth2User, registrationId);
 		}
 
 		if (isAccountLinking) {
@@ -81,8 +81,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 		return null;
 	}
 
-	private OAuth2User handleExistingUser(User user, OAuth2User oAuth2User) {
-		return new CustomUserDetails(user, oAuth2User.getAttributes());
+	private OAuth2User handleExistingUser(User user, OAuth2User oAuth2User, String registrationId) {
+		return new CustomUserDetails(user, oAuth2User.getAttributes(), registrationId);
 	}
 
 	private OAuth2User handleAccountLinking(String userId, OAuth2Response oAuth2Response,
@@ -96,7 +96,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 		existingUser.updateSocialInfo(oAuth2Response.getProviderId(), SocialType.getSocialType(registrationId));
 		User savedUser = userRepository.save(existingUser);
 
-		return new CustomUserDetails(savedUser, oAuth2User.getAttributes());
+		return new CustomUserDetails(savedUser, oAuth2User.getAttributes(), registrationId);
 	}
 
 	private OAuth2User handleNewUser(OAuth2Response oAuth2Response, OAuth2User oAuth2User, String registrationId) {
@@ -108,7 +108,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 			.socialType(SocialType.getSocialType(registrationId))
 			.build();
 
-		return new CustomUserDetails(tempUser, oAuth2User.getAttributes());
+		return new CustomUserDetails(tempUser, oAuth2User.getAttributes(), registrationId);
 	}
 
 	private void validateUserId(String userId) {

--- a/src/main/java/doldol_server/doldol/common/config/PasswordConfig.java
+++ b/src/main/java/doldol_server/doldol/common/config/PasswordConfig.java
@@ -1,0 +1,15 @@
+package doldol_server.doldol.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+}

--- a/src/main/java/doldol_server/doldol/common/config/SecurityConfig.java
+++ b/src/main/java/doldol_server/doldol/common/config/SecurityConfig.java
@@ -1,5 +1,18 @@
 package doldol_server.doldol.common.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.web.cors.CorsConfigurationSource;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import doldol_server.doldol.auth.filter.CustomLogoutFilter;
@@ -14,20 +27,6 @@ import doldol_server.doldol.auth.resolver.CustomOAuth2ParameterResolver;
 import doldol_server.doldol.auth.service.CustomOAuth2UserService;
 import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;
-
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.authentication.logout.LogoutFilter;
-import org.springframework.web.cors.CorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
@@ -89,10 +88,5 @@ public class SecurityConfig {
 	@Bean
 	public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
 		return configuration.getAuthenticationManager();
-	}
-
-	@Bean
-	public BCryptPasswordEncoder bCryptPasswordEncoder() {
-		return new BCryptPasswordEncoder();
 	}
 }

--- a/src/main/java/doldol_server/doldol/common/config/SecurityConfig.java
+++ b/src/main/java/doldol_server/doldol/common/config/SecurityConfig.java
@@ -43,7 +43,6 @@ public class SecurityConfig {
 
 	private final TokenProvider tokenProvider;
 	private final ObjectMapper objectMapper;
-	private final Validator validator;
 	private final CorsConfigurationSource corsConfigurationSource;
 	private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
 	private final CustomOAuth2FailureHandler customOAuth2FailureHandler;
@@ -72,7 +71,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(WHITELIST).permitAll()
 				.anyRequest().authenticated())
-			.addFilterAt(new CustomUserLoginFilter(authenticationManager, tokenProvider, objectMapper, validator),
+			.addFilterAt(new CustomUserLoginFilter(authenticationManager, tokenProvider, objectMapper),
 				UsernamePasswordAuthenticationFilter.class)
 			.addFilterAfter(new JwtAuthenticationFilter(tokenProvider, WHITELIST, objectMapper),
 				CustomUserLoginFilter.class)

--- a/src/main/java/doldol_server/doldol/common/constants/TokenConstant.java
+++ b/src/main/java/doldol_server/doldol/common/constants/TokenConstant.java
@@ -2,10 +2,9 @@ package doldol_server.doldol.common.constants;
 
 public class TokenConstant {
 
-    public static final String BEARER_FIX = "Bearer ";
-    public static final int MINUTE_IN_MILLISECONDS = 60 * 1000;
-    public static final long DAYS_IN_MILLISECONDS = 24 * 60 * 60 * 1000L;
-    public static final int ACCESS_TOKEN_EXPIRATION_MINUTE = 30;
-    public static final int REFRESH_TOKEN_EXPIRATION_DAYS = 14;
-    public static final int TEMP_ACCESS_TOKEN_EXPIRATION_MINUTE = 10;
+	public static final String BEARER_FIX = "Bearer ";
+	public static final int MINUTE_IN_MILLISECONDS = 60 * 1000;
+	public static final long DAYS_IN_MILLISECONDS = 24 * 60 * 60 * 1000L;
+	public static final int ACCESS_TOKEN_EXPIRATION_MINUTE = 30;
+	public static final int REFRESH_TOKEN_EXPIRATION_DAYS = 14;
 }

--- a/src/test/java/doldol_server/doldol/auth/jwt/TokenProviderTest.java
+++ b/src/test/java/doldol_server/doldol/auth/jwt/TokenProviderTest.java
@@ -196,7 +196,7 @@ class TokenProviderTest {
 		assertThat(authentication.getPrincipal()).isEqualTo(customUserDetails);
 
 		CustomUserDetails principal = (CustomUserDetails)authentication.getPrincipal();
-		assertThat(principal.getUsername()).isEqualTo(USER_ID);
+		assertThat(principal.getLoginId()).isEqualTo(USER_ID);
 		assertThat(authentication.getAuthorities()).isNotEmpty();
 	}
 


### PR DESCRIPTION
## 📄 PR 내용

- 카카오 로그인 후 db에 socialId 필드가 없다면 소셜 회원가입 페이지로 리다이렉션 합니다. 해당 소셜 회원가입 페이지 로직은 DTO 클래스의 필드를 제외한 기존 자체 서비스 회원가입 로직과 동일합니다. 다만 CustomOAuth2UserService, CustomOAuth2SuccessHandler 클래스에서 소셜 로그인 후 자체 서비스와 연동된 유저인지, 소셜 로그인으로만 진행한 유저인지, 처음 소셜 회원가입을 진행 한 유저인지 구분을 합니다. 
- 처음에는 socialId 유무로 이미 소셜 로그인을 사용한 사람인지 아닌지로 구별하고 소셜 로그인과 연동을 시도하는거라면 프론트측에서 쿼리파라미터로 userId 유무로 연동/회원가입을 구분합니다.

## 📝 수정 상세 내용 

- CustomUserDetails 사용자 식별값을 userId가 존재한다면 userId, 아니라면 socialId로 지정
- 회원가입 로직은 기존 자체 서비스 회원가입 로직과 동일

## ✅ 체크리스트

- [X] 소셜 로그인 후 메인페이지 / 추가 정보 기입 페이지로 리다이렉션
- [X] 추가 정보 기입 페이지로 리다이렉션 할 때 쿼리파라미터로 userId 탑재


## 📍 레퍼런스

- X