### PR TITLE
[FEAT] 롤링페이퍼 생성 및 초대 관련 API

### DIFF
--- a/src/main/java/doldol_server/doldol/auth/filter/CustomUserLoginFilter.java
+++ b/src/main/java/doldol_server/doldol/auth/filter/CustomUserLoginFilter.java
@@ -2,16 +2,7 @@ package doldol_server.doldol.auth.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import doldol_server.doldol.auth.dto.request.LoginRequest;
 import doldol_server.doldol.auth.jwt.TokenProvider;
-import doldol_server.doldol.auth.util.ResponseUtil;
-import doldol_server.doldol.common.exception.AuthErrorCode;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.Validator;
-
-import java.io.IOException;
-import java.util.Set;
 
 import org.springframework.security.authentication.AuthenticationManager;
 

--- a/src/main/java/doldol_server/doldol/auth/filter/CustomUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/doldol_server/doldol/auth/filter/CustomUsernamePasswordAuthenticationFilter.java
@@ -15,7 +15,7 @@ import doldol_server.doldol.auth.jwt.TokenProvider;
 import doldol_server.doldol.auth.jwt.dto.UserTokenResponse;
 import doldol_server.doldol.auth.util.CookieUtil;
 import doldol_server.doldol.auth.util.ResponseUtil;
-import doldol_server.doldol.common.exception.AuthErrorCode;
+import doldol_server.doldol.common.exception.errorCode.AuthErrorCode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/doldol_server/doldol/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/doldol_server/doldol/auth/filter/JwtAuthenticationFilter.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import doldol_server.doldol.auth.jwt.TokenProvider;
 import doldol_server.doldol.auth.util.ResponseUtil;
-import doldol_server.doldol.common.exception.AuthErrorCode;
+import doldol_server.doldol.common.exception.errorCode.AuthErrorCode;
 import io.jsonwebtoken.IncorrectClaimException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/src/main/java/doldol_server/doldol/auth/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/doldol_server/doldol/auth/handler/CustomAccessDeniedHandler.java
@@ -2,7 +2,7 @@ package doldol_server.doldol.auth.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import doldol_server.doldol.auth.util.ResponseUtil;
-import doldol_server.doldol.common.exception.AuthErrorCode;
+import doldol_server.doldol.common.exception.errorCode.AuthErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;

--- a/src/main/java/doldol_server/doldol/auth/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/doldol_server/doldol/auth/handler/CustomAuthenticationEntryPoint.java
@@ -2,7 +2,7 @@ package doldol_server.doldol.auth.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import doldol_server.doldol.auth.util.ResponseUtil;
-import doldol_server.doldol.common.exception.AuthErrorCode;
+import doldol_server.doldol.common.exception.errorCode.AuthErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;

--- a/src/main/java/doldol_server/doldol/auth/handler/CustomOAuth2FailureHandler.java
+++ b/src/main/java/doldol_server/doldol/auth/handler/CustomOAuth2FailureHandler.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import doldol_server.doldol.auth.util.ResponseUtil;
-import doldol_server.doldol.common.exception.AuthErrorCode;
+import doldol_server.doldol.common.exception.errorCode.AuthErrorCode;
 import doldol_server.doldol.common.exception.CustomOAuth2Exception;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/doldol_server/doldol/auth/service/AuthService.java
+++ b/src/main/java/doldol_server/doldol/auth/service/AuthService.java
@@ -19,7 +19,7 @@ import doldol_server.doldol.auth.jwt.dto.UserTokenResponse;
 import doldol_server.doldol.auth.util.CookieUtil;
 import doldol_server.doldol.auth.util.GeneratorRandomUtil;
 import doldol_server.doldol.common.constants.TokenConstant;
-import doldol_server.doldol.common.exception.AuthErrorCode;
+import doldol_server.doldol.common.exception.errorCode.AuthErrorCode;
 import doldol_server.doldol.common.exception.CustomException;
 import doldol_server.doldol.user.entity.SocialType;
 import doldol_server.doldol.user.entity.User;

--- a/src/main/java/doldol_server/doldol/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/doldol_server/doldol/auth/service/CustomOAuth2UserService.java
@@ -12,8 +12,8 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 import doldol_server.doldol.auth.dto.CustomUserDetails;
 import doldol_server.doldol.auth.dto.OAuth2Response;
-import doldol_server.doldol.common.exception.AuthErrorCode;
-import doldol_server.doldol.common.exception.CommonErrorCode;
+import doldol_server.doldol.common.exception.errorCode.AuthErrorCode;
+import doldol_server.doldol.common.exception.errorCode.CommonErrorCode;
 import doldol_server.doldol.common.exception.CustomOAuth2Exception;
 import doldol_server.doldol.user.entity.SocialType;
 import doldol_server.doldol.user.entity.User;

--- a/src/main/java/doldol_server/doldol/auth/service/EmailService.java
+++ b/src/main/java/doldol_server/doldol/auth/service/EmailService.java
@@ -10,7 +10,7 @@ import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
 import doldol_server.doldol.common.exception.CustomException;
-import doldol_server.doldol.common.exception.MailErrorCode;
+import doldol_server.doldol.common.exception.errorCode.MailErrorCode;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/doldol_server/doldol/auth/util/ResponseUtil.java
+++ b/src/main/java/doldol_server/doldol/auth/util/ResponseUtil.java
@@ -2,7 +2,7 @@ package doldol_server.doldol.auth.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import doldol_server.doldol.common.exception.ErrorCode;
+import doldol_server.doldol.common.exception.errorCode.ErrorCode;
 import doldol_server.doldol.common.response.ApiResponse;
 import doldol_server.doldol.common.response.ErrorResponse;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/doldol_server/doldol/common/config/SecurityConfig.java
+++ b/src/main/java/doldol_server/doldol/common/config/SecurityConfig.java
@@ -25,7 +25,6 @@ import doldol_server.doldol.auth.handler.CustomOAuth2SuccessHandler;
 import doldol_server.doldol.auth.jwt.TokenProvider;
 import doldol_server.doldol.auth.resolver.CustomOAuth2ParameterResolver;
 import doldol_server.doldol.auth.service.CustomOAuth2UserService;
-import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -39,7 +38,8 @@ public class SecurityConfig {
 		"/v3/api-docs/**",
 		"/swagger-resources/**",
 		"/webjars/**",
-		"/actuator/**"
+		"/actuator/**",
+		"/papers/invite"
 	};
 
 	private final TokenProvider tokenProvider;

--- a/src/main/java/doldol_server/doldol/common/config/SwaggerConfig.java
+++ b/src/main/java/doldol_server/doldol/common/config/SwaggerConfig.java
@@ -24,12 +24,12 @@ public class SwaggerConfig {
 	}
 
 	private Components authComponent() {
-		return new Components().addSecuritySchemes("jwt-token",
+		return new Components().addSecuritySchemes("jwt",
 			new SecurityScheme()
 				.type(SecurityScheme.Type.HTTP)
 				.in(SecurityScheme.In.HEADER)
 				.name("Authorization")
-				.scheme("bearer")
+				.scheme("Bearer")
 				.bearerFormat("JWT"));
 	}
 }

--- a/src/main/java/doldol_server/doldol/common/exception/CustomException.java
+++ b/src/main/java/doldol_server/doldol/common/exception/CustomException.java
@@ -1,5 +1,6 @@
 package doldol_server.doldol.common.exception;
 
+import doldol_server.doldol.common.exception.errorCode.ErrorCode;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/doldol_server/doldol/common/exception/CustomOAuth2Exception.java
+++ b/src/main/java/doldol_server/doldol/common/exception/CustomOAuth2Exception.java
@@ -3,6 +3,7 @@ package doldol_server.doldol.common.exception;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
 
+import doldol_server.doldol.common.exception.errorCode.ErrorCode;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/doldol_server/doldol/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/doldol_server/doldol/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,8 @@
 package doldol_server.doldol.common.exception;
 
+import doldol_server.doldol.common.exception.errorCode.AuthErrorCode;
+import doldol_server.doldol.common.exception.errorCode.CommonErrorCode;
+import doldol_server.doldol.common.exception.errorCode.ErrorCode;
 import doldol_server.doldol.common.response.ErrorResponse;
 
 import java.util.HashMap;

--- a/src/main/java/doldol_server/doldol/common/exception/UserErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/UserErrorCode.java
@@ -1,0 +1,18 @@
+package doldol_server.doldol.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+import doldol_server.doldol.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U-001", "회원을 찾을 수 없습니다."),
+	;
+
+	private HttpStatus httpStatus;
+	private String code;
+	private String message;
+}

--- a/src/main/java/doldol_server/doldol/common/exception/errorCode/AuthErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/errorCode/AuthErrorCode.java
@@ -1,4 +1,4 @@
-package doldol_server.doldol.common.exception;
+package doldol_server.doldol.common.exception.errorCode;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/doldol_server/doldol/common/exception/errorCode/CommonErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/errorCode/CommonErrorCode.java
@@ -1,4 +1,4 @@
-package doldol_server.doldol.common.exception;
+package doldol_server.doldol.common.exception.errorCode;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/doldol_server/doldol/common/exception/errorCode/ErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/errorCode/ErrorCode.java
@@ -1,4 +1,4 @@
-package doldol_server.doldol.common.exception;
+package doldol_server.doldol.common.exception.errorCode;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/doldol_server/doldol/common/exception/errorCode/MailErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/errorCode/MailErrorCode.java
@@ -1,7 +1,8 @@
-package doldol_server.doldol.common.exception;
+package doldol_server.doldol.common.exception.errorCode;
 
 import org.springframework.http.HttpStatus;
 
+import doldol_server.doldol.common.exception.errorCode.ErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/doldol_server/doldol/common/exception/errorCode/PaperErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/errorCode/PaperErrorCode.java
@@ -2,7 +2,6 @@ package doldol_server.doldol.common.exception.errorCode;
 
 import org.springframework.http.HttpStatus;
 
-import doldol_server.doldol.common.exception.ErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/doldol_server/doldol/common/exception/errorCode/PaperErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/errorCode/PaperErrorCode.java
@@ -10,6 +10,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum PaperErrorCode implements ErrorCode {
 	PAPER_NOT_FOUND(HttpStatus.NOT_FOUND, "P-001", "롤링페이퍼를 찾을 수 없습니다."),
+	PARTICIPANT_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "P-002", "롤링페이퍼에 사용자가 이미 존재합니다."),
+
 	;
 
 	private HttpStatus httpStatus;

--- a/src/main/java/doldol_server/doldol/common/exception/errorCode/PaperErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/errorCode/PaperErrorCode.java
@@ -1,0 +1,18 @@
+package doldol_server.doldol.common.exception.errorCode;
+
+import org.springframework.http.HttpStatus;
+
+import doldol_server.doldol.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PaperErrorCode implements ErrorCode {
+	PAPER_NOT_FOUND(HttpStatus.NOT_FOUND, "P-001", "롤링페이퍼를 찾을 수 없습니다."),
+	;
+
+	private HttpStatus httpStatus;
+	private String code;
+	private String message;
+}

--- a/src/main/java/doldol_server/doldol/common/exception/errorCode/UserErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/errorCode/UserErrorCode.java
@@ -1,8 +1,8 @@
-package doldol_server.doldol.common.exception;
+package doldol_server.doldol.common.exception.errorCode;
 
 import org.springframework.http.HttpStatus;
 
-import doldol_server.doldol.common.exception.ErrorCode;
+import doldol_server.doldol.common.exception.errorCode.ErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/doldol_server/doldol/rollingPaper/controller/PaperController.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/controller/PaperController.java
@@ -70,7 +70,7 @@ public class PaperController {
 		description = "링크를 통해 생성된 롤링페이퍼 초대장 조회")
 	public ResponseEntity<ApiResponse<PaperResponse>> getPaperLink(
 		@RequestParam("code") String invitationCode) {
-		PaperResponse response = null;
+		PaperResponse response = paperService.getInvitation(invitationCode);
 		return ResponseEntity.ok(ApiResponse.ok(response));
 	}
 

--- a/src/main/java/doldol_server/doldol/rollingPaper/controller/PaperController.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/controller/PaperController.java
@@ -17,20 +17,26 @@ import doldol_server.doldol.auth.dto.CustomUserDetails;
 import doldol_server.doldol.common.response.ApiResponse;
 import doldol_server.doldol.rollingPaper.dto.request.JoinPaperRequest;
 import doldol_server.doldol.rollingPaper.dto.request.PaperRequest;
+import doldol_server.doldol.rollingPaper.dto.response.CreatePaperResponse;
 import doldol_server.doldol.rollingPaper.dto.response.MessageListResponse;
 import doldol_server.doldol.rollingPaper.dto.response.PaperListResponse;
 import doldol_server.doldol.rollingPaper.dto.response.PaperResponse;
 import doldol_server.doldol.rollingPaper.entity.MessageType;
+import doldol_server.doldol.rollingPaper.service.PaperService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @Tag(name = "롤링페이퍼")
 @RestController
 @RequestMapping("/papers")
+@RequiredArgsConstructor
 public class PaperController {
+
+	private final PaperService paperService;
 
 	@GetMapping("/messages")
 	@Operation(
@@ -51,10 +57,10 @@ public class PaperController {
 		summary = "롤링페이퍼 생성 API",
 		description = "롤링페이퍼 생성",
 		security = {@SecurityRequirement(name = "jwt")})
-	public ResponseEntity<ApiResponse<PaperResponse>> createRollingPaper(
+	public ResponseEntity<ApiResponse<CreatePaperResponse>> createRollingPaper(
 		@RequestBody @Valid PaperRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
-		PaperResponse response = null;
+		CreatePaperResponse response = paperService.createPaper(request, userDetails.getUserId());
 		return ResponseEntity.ok(ApiResponse.created(response));
 	}
 

--- a/src/main/java/doldol_server/doldol/rollingPaper/controller/PaperController.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/controller/PaperController.java
@@ -80,8 +80,9 @@ public class PaperController {
 		description = "초대받은 롤링페이퍼에 참여",
 		security = {@SecurityRequirement(name = "jwt")})
 	public ResponseEntity<ApiResponse<Void>> joinRollingPaper(
-		@ParameterObject @RequestBody @Valid JoinPaperRequest request,
+		@RequestBody @Valid JoinPaperRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		paperService.joinPaper(request, userDetails.getUserId());
 		return ResponseEntity.ok(ApiResponse.noContent());
 	}
 

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/request/JoinPaperRequest.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/request/JoinPaperRequest.java
@@ -5,8 +5,8 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(name = "JoinPaperRequest: 롤링페이퍼 초대 요청 Dto")
 public record JoinPaperRequest(
-	@NotNull(message = "롤링페이퍼 ID는 필수입니다.")
-	@Schema(description = "롤링페이퍼 ID", example = "1")
-	Long paperId
+	@NotNull(message = "롤링페이퍼 참여코드는 필수입니다.")
+	@Schema(description = "롤링페이퍼 참여 코드", example = "1b10e79f-6511-47cd-89b4-7910460d81b5")
+	String invitationCode
 ) {
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/response/CreatePaperResponse.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/response/CreatePaperResponse.java
@@ -1,21 +1,22 @@
-package doldol_server.doldol.rollingPaper.dto.request;
+package doldol_server.doldol.rollingPaper.dto.response;
 
 import java.time.LocalDateTime;
 
+import doldol_server.doldol.rollingPaper.entity.Paper;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 
-@Schema(name = "PaperRequest: 롤링페이퍼 생성 요청 Dto")
-public record PaperRequest(
-	@NotNull(message = "단체 이름은 필수입니다.")
+@Schema(name = "PaperResponse: 롤링페이퍼 생성 응답 Dto")
+public record CreatePaperResponse(
 	@Schema(description = "단체 이름", example = "[KB] IT's Your Life 6기 16회차")
 	String name,
 
 	@Schema(description = "단체 설명", example = "KB 16회차 짱짱맨 영원하라.")
 	String description,
 
-	@NotNull(message = "메세지 공개 날짜는 필수입니다.")
 	@Schema(description = "메세지 공개 날짜", example = "2025-05-26T11:44:30.327959")
 	LocalDateTime openDate
 ) {
+	public static CreatePaperResponse of(Paper paper) {
+		return new CreatePaperResponse(paper.getName(), paper.getDescription(), paper.getOpenDate());
+	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/response/PaperResponse.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/response/PaperResponse.java
@@ -1,10 +1,10 @@
 package doldol_server.doldol.rollingPaper.dto.response;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "PaperResponse: 롤링페이퍼 생성 응답 Dto")
+@Schema(name = "PaperResponse: 롤링페이퍼 조회 응답 Dto")
 public record PaperResponse(
 	@Schema(description = "단체 이름", example = "[KB] IT's Your Life 6기 16회차")
 	String name,
@@ -19,6 +19,6 @@ public record PaperResponse(
 	int messageCount,
 
 	@Schema(description = "메세지 공개 날짜", example = "2025-05-26T11:44:30.327959")
-	LocalDate openDate
+	LocalDateTime openDate
 ) {
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/response/PaperResponse.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/response/PaperResponse.java
@@ -2,8 +2,11 @@ package doldol_server.doldol.rollingPaper.dto.response;
 
 import java.time.LocalDateTime;
 
+import doldol_server.doldol.rollingPaper.entity.Paper;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
+@Builder
 @Schema(name = "PaperResponse: 롤링페이퍼 조회 응답 Dto")
 public record PaperResponse(
 	@Schema(description = "단체 이름", example = "[KB] IT's Your Life 6기 16회차")
@@ -21,4 +24,13 @@ public record PaperResponse(
 	@Schema(description = "메세지 공개 날짜", example = "2025-05-26T11:44:30.327959")
 	LocalDateTime openDate
 ) {
+	public static PaperResponse of(Paper paper) {
+		return PaperResponse.builder()
+			.name(paper.getName())
+			.description(paper.getDescription())
+			.participantsCount(paper.getParticipantsCount())
+			.messageCount(paper.getMessageCount())
+			.openDate(paper.getOpenDate())
+			.build();
+	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/entity/Paper.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/entity/Paper.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -34,11 +35,19 @@ public class Paper extends BaseEntity {
 	private String link;
 
 	@Column(name = "participants_count")
-	private Long participantsCount;
+	private int participantsCount = 0;
 
 	@Column(name = "message_count")
-	private Long messageCount;
+	private int messageCount = 0;
 
 	@Column(name = "is_deleted")
 	private boolean isDeleted = false;
+
+	@Builder
+	public Paper(String name, String description, LocalDateTime openDate, String link) {
+		this.name = name;
+		this.description = description;
+		this.openDate = openDate;
+		this.link = link;
+	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/entity/Paper.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/entity/Paper.java
@@ -31,6 +31,9 @@ public class Paper extends BaseEntity {
 	@Column(name = "open_date", nullable = false)
 	private LocalDateTime openDate;
 
+	@Column(name = "invitation_code", nullable = false)
+	private String invitationCode;
+
 	@Column(name = "link", nullable = false, unique = true)
 	private String link;
 
@@ -44,10 +47,11 @@ public class Paper extends BaseEntity {
 	private boolean isDeleted = false;
 
 	@Builder
-	public Paper(String name, String description, LocalDateTime openDate, String link) {
+	public Paper(String name, String description, LocalDateTime openDate, String invitationCode, String link) {
 		this.name = name;
 		this.description = description;
 		this.openDate = openDate;
+		this.invitationCode = invitationCode;
 		this.link = link;
 	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/entity/Paper.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/entity/Paper.java
@@ -54,4 +54,8 @@ public class Paper extends BaseEntity {
 		this.invitationCode = invitationCode;
 		this.link = link;
 	}
+
+	public void addParticipant() {
+		participantsCount++;
+	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/entity/Participant.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/entity/Participant.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -33,4 +34,11 @@ public class Participant extends BaseEntity {
 
 	@Column(name = "is_master", nullable = false)
 	private boolean isMaster;
+
+	@Builder
+	public Participant(User user, Paper paper, boolean isMaster) {
+		this.user = user;
+		this.paper = paper;
+		this.isMaster = isMaster;
+	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/repository/PaperRepository.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/repository/PaperRepository.java
@@ -1,0 +1,10 @@
+package doldol_server.doldol.rollingPaper.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import doldol_server.doldol.rollingPaper.entity.Paper;
+
+@Repository
+public interface PaperRepository extends JpaRepository<Paper, Long> {
+}

--- a/src/main/java/doldol_server/doldol/rollingPaper/repository/PaperRepository.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/repository/PaperRepository.java
@@ -1,5 +1,7 @@
 package doldol_server.doldol.rollingPaper.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,5 @@ import doldol_server.doldol.rollingPaper.entity.Paper;
 
 @Repository
 public interface PaperRepository extends JpaRepository<Paper, Long> {
+	Optional<Paper> findByInvitationCode(String invitationCode);
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/repository/ParticipantRepository.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/repository/ParticipantRepository.java
@@ -1,0 +1,8 @@
+package doldol_server.doldol.rollingPaper.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import doldol_server.doldol.rollingPaper.entity.Participant;
+
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+}

--- a/src/main/java/doldol_server/doldol/rollingPaper/repository/ParticipantRepository.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/repository/ParticipantRepository.java
@@ -2,7 +2,10 @@ package doldol_server.doldol.rollingPaper.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import doldol_server.doldol.rollingPaper.entity.Paper;
 import doldol_server.doldol.rollingPaper.entity.Participant;
+import doldol_server.doldol.user.entity.User;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+	boolean existsByUserAndPaper(User user, Paper paper);
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/PaperService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/PaperService.java
@@ -1,11 +1,14 @@
 package doldol_server.doldol.rollingPaper.service;
 
+import static doldol_server.doldol.common.exception.errorCode.PaperErrorCode.*;
+
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import doldol_server.doldol.common.exception.CustomException;
 import doldol_server.doldol.rollingPaper.dto.request.PaperRequest;
 import doldol_server.doldol.rollingPaper.dto.response.CreatePaperResponse;
 import doldol_server.doldol.rollingPaper.dto.response.PaperResponse;
@@ -43,5 +46,11 @@ public class PaperService {
 
 	private String createInvitationCode() {
 		return UUID.randomUUID().toString();
+	}
+
+	public PaperResponse getInvitation(String invitationCode) {
+		Paper paper = paperRepository.findByInvitationCode(invitationCode)
+			.orElseThrow(() -> new CustomException(PAPER_NOT_FOUND));
+		return PaperResponse.of(paper);
 	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/PaperService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/PaperService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import doldol_server.doldol.rollingPaper.dto.request.PaperRequest;
 import doldol_server.doldol.rollingPaper.dto.response.CreatePaperResponse;
+import doldol_server.doldol.rollingPaper.dto.response.PaperResponse;
 import doldol_server.doldol.rollingPaper.entity.Paper;
 import doldol_server.doldol.rollingPaper.repository.PaperRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,12 +26,13 @@ public class PaperService {
 
 	@Transactional
 	public CreatePaperResponse createPaper(PaperRequest request, Long userId) {
-
+		String invitationCode = createInvitationCode();
 		Paper paper = Paper.builder()
 			.name(request.name())
 			.description(request.description())
 			.openDate(request.openDate())
-			.link(createLink())
+			.invitationCode(invitationCode)
+			.link(defaultPaperLink + invitationCode)
 			.build();
 		paperRepository.save(paper);
 
@@ -39,7 +41,7 @@ public class PaperService {
 		return CreatePaperResponse.of(paper);
 	}
 
-	private String createLink() {
-		return defaultPaperLink + UUID.randomUUID();
+	private String createInvitationCode() {
+		return UUID.randomUUID().toString();
 	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/PaperService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/PaperService.java
@@ -38,7 +38,6 @@ public class PaperService {
 			.invitationCode(invitationCode)
 			.link(defaultPaperLink + invitationCode)
 			.build();
-		paper.addParticipant();
 		paperRepository.save(paper);
 
 		participantService.addUser(userId, paper, true);
@@ -59,7 +58,6 @@ public class PaperService {
 		if (participantService.existUserInPaper(userId, paper)) {
 			throw new CustomException(PARTICIPANT_ALREADY_EXIST);
 		}
-		paper.addParticipant();
 
 		participantService.addUser(userId, paper, false);
 	}

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/PaperService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/PaperService.java
@@ -1,0 +1,45 @@
+package doldol_server.doldol.rollingPaper.service;
+
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import doldol_server.doldol.rollingPaper.dto.request.PaperRequest;
+import doldol_server.doldol.rollingPaper.dto.response.CreatePaperResponse;
+import doldol_server.doldol.rollingPaper.entity.Paper;
+import doldol_server.doldol.rollingPaper.repository.PaperRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PaperService {
+
+	@Value("${paper.default.link}")
+	private String defaultPaperLink;
+
+	private final PaperRepository paperRepository;
+	private final ParticipantService participantService;
+
+	@Transactional
+	public CreatePaperResponse createPaper(PaperRequest request, Long userId) {
+
+		Paper paper = Paper.builder()
+			.name(request.name())
+			.description(request.description())
+			.openDate(request.openDate())
+			.link(createLink())
+			.build();
+		paperRepository.save(paper);
+
+		participantService.createParticipant(userId, paper);
+
+		return CreatePaperResponse.of(paper);
+	}
+
+	private String createLink() {
+		return defaultPaperLink + UUID.randomUUID();
+	}
+}

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/ParticipantService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/ParticipantService.java
@@ -1,0 +1,30 @@
+package doldol_server.doldol.rollingPaper.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import doldol_server.doldol.rollingPaper.entity.Paper;
+import doldol_server.doldol.rollingPaper.entity.Participant;
+import doldol_server.doldol.rollingPaper.repository.ParticipantRepository;
+import doldol_server.doldol.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ParticipantService {
+
+	private final ParticipantRepository participantRepository;
+	private final UserService userService;
+
+	@Transactional
+	public void createParticipant(Long userId, Paper paper) {
+		Participant master = Participant.builder()
+			.user(userService.getById(userId))
+			.paper(paper)
+			.isMaster(true)
+			.build();
+
+		participantRepository.save(master);
+	}
+}

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/ParticipantService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/ParticipantService.java
@@ -25,6 +25,7 @@ public class ParticipantService {
 			.paper(paper)
 			.isMaster(isMaster)
 			.build();
+		paper.addParticipant();
 
 		participantRepository.save(participant);
 	}

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/ParticipantService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/ParticipantService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import doldol_server.doldol.rollingPaper.entity.Paper;
 import doldol_server.doldol.rollingPaper.entity.Participant;
 import doldol_server.doldol.rollingPaper.repository.ParticipantRepository;
+import doldol_server.doldol.user.entity.User;
 import doldol_server.doldol.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 
@@ -18,13 +19,18 @@ public class ParticipantService {
 	private final UserService userService;
 
 	@Transactional
-	public void createParticipant(Long userId, Paper paper) {
-		Participant master = Participant.builder()
+	public void addUser(Long userId, Paper paper, boolean isMaster) {
+		Participant participant = Participant.builder()
 			.user(userService.getById(userId))
 			.paper(paper)
-			.isMaster(true)
+			.isMaster(isMaster)
 			.build();
 
-		participantRepository.save(master);
+		participantRepository.save(participant);
+	}
+
+	public boolean existUserInPaper(Long userId, Paper paper) {
+		User user = userService.getById(userId);
+		return participantRepository.existsByUserAndPaper(user, paper);
 	}
 }

--- a/src/main/java/doldol_server/doldol/user/service/UserService.java
+++ b/src/main/java/doldol_server/doldol/user/service/UserService.java
@@ -1,0 +1,22 @@
+package doldol_server.doldol.user.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import doldol_server.doldol.common.exception.CustomException;
+import doldol_server.doldol.common.exception.UserErrorCode;
+import doldol_server.doldol.user.entity.User;
+import doldol_server.doldol.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserService {
+
+	private final UserRepository userRepository;
+
+	public User getById(Long userId) {
+		return userRepository.findById(userId).orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+	}
+}

--- a/src/main/java/doldol_server/doldol/user/service/UserService.java
+++ b/src/main/java/doldol_server/doldol/user/service/UserService.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import doldol_server.doldol.common.exception.CustomException;
-import doldol_server.doldol.common.exception.UserErrorCode;
+import doldol_server.doldol.common.exception.errorCode.UserErrorCode;
 import doldol_server.doldol.user.entity.User;
 import doldol_server.doldol.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/doldol_server/doldol/auth/service/AuthServiceTest.java
+++ b/src/test/java/doldol_server/doldol/auth/service/AuthServiceTest.java
@@ -21,7 +21,7 @@ import doldol_server.doldol.auth.dto.request.RegisterRequest;
 import doldol_server.doldol.auth.jwt.TokenProvider;
 import doldol_server.doldol.auth.jwt.dto.UserTokenResponse;
 import doldol_server.doldol.common.ServiceTest;
-import doldol_server.doldol.common.exception.AuthErrorCode;
+import doldol_server.doldol.common.exception.errorCode.AuthErrorCode;
 import doldol_server.doldol.common.exception.CustomException;
 import doldol_server.doldol.user.entity.User;
 import doldol_server.doldol.user.repository.UserRepository;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -82,3 +82,6 @@ cors:
   allow:
     origins: localhost:8080
 
+paper:
+  default:
+    link: http://localhost:8080/paper?code=


### PR DESCRIPTION
## 📄 PR 내용

<!--- 작업에 대한 요약 설명을 작성해 주세요. -->
- 롤링페이퍼 생성 및 초대 관련 API를 완성했습니다~~ 
- #44 

## 📝 수정 상세 내용 

<!--- 작업 전과 후의 변화를 설명해 주세요. -->
- 롤링페이퍼 참여 링크는 일단 임의로 설정했습니다.
- 잔잔하게(?) dto가 변경되었어요
- 스웨거로 테스트가 안돼서 보니 스웨거 인증 설정 이름이 잘못 되어 있어서 고쳤습니닷..
- 에러 코드가 많아질 것 같아 `common/exception` 안에 `errorCode` 패키지를 따로 생성했습니다!

## ✅ 체크리스트

- [x] 롤링페이퍼 생성 API
- [x] 롤링페이퍼 초대 조회 API
- [x] 롤링페이퍼 참여 API

## 기타
- 코멘트 최이주 파이팅 해주세요~~