### PR TITLE
[FEAT] 메시지 작성

### DIFF
--- a/src/main/java/doldol_server/doldol/auth/controller/AuthController.java
+++ b/src/main/java/doldol_server/doldol/auth/controller/AuthController.java
@@ -37,7 +37,7 @@ public class AuthController {
 		description = "이이디 중복 확인")
 	public ResponseEntity<ApiResponse<Void>> checkIdDuplicate(@RequestBody @Valid IdCheckRequest idCheckRequest) {
 		authService.checkIdDuplicate(idCheckRequest.id());
-		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.noContent());
+		return ResponseEntity.ok(ApiResponse.noContent());
 	}
 
 	@PostMapping("/check-email")
@@ -47,7 +47,7 @@ public class AuthController {
 	public ResponseEntity<ApiResponse<Void>> checkEmailDuplicate(
 		@RequestBody @Valid EmailCheckRequest emailCheckRequest) {
 		authService.checkEmailDuplicate(emailCheckRequest.email());
-		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.noContent());
+		return ResponseEntity.ok(ApiResponse.noContent());
 	}
 
 	@PostMapping("/check-phone")
@@ -57,7 +57,7 @@ public class AuthController {
 	public ResponseEntity<ApiResponse<Void>> checkphoneDuplicate(
 		@RequestBody @Valid PhoneCheckRequest phoneCheckRequest) {
 		authService.checkPhoneDuplicate(phoneCheckRequest.phone());
-		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.noContent());
+		return ResponseEntity.ok(ApiResponse.noContent());
 	}
 
 	@PostMapping("/email/send-code")
@@ -67,7 +67,7 @@ public class AuthController {
 	public ResponseEntity<ApiResponse<Void>> sendVerificationCode(
 		@RequestBody @Valid EmailCodeSendRequest emailCodeSendRequest) {
 		authService.sendVerificationCode(emailCodeSendRequest.email());
-		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.noContent());
+		return ResponseEntity.ok(ApiResponse.noContent());
 	}
 
 	@PostMapping("/email/verify-code")
@@ -77,7 +77,7 @@ public class AuthController {
 	public ResponseEntity<ApiResponse<Void>> validateVerificationCode(
 		@RequestBody @Valid EmailCodeVerifyRequest emailCodeVerifyRequest) {
 		authService.validateVerificationCode(emailCodeVerifyRequest.email(), emailCodeVerifyRequest.code());
-		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.noContent());
+		return ResponseEntity.ok(ApiResponse.noContent());
 	}
 
 	@PostMapping("/register")
@@ -86,7 +86,7 @@ public class AuthController {
 		description = "자체 서비 회원가입")
 	public ResponseEntity<ApiResponse<Void>> register(@RequestBody @Valid RegisterRequest registerRequest) {
 		authService.register(registerRequest);
-		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.noContent());
+		return ResponseEntity.ok(ApiResponse.noContent());
 	}
 
 	@PostMapping("/oauth/register")
@@ -96,7 +96,7 @@ public class AuthController {
 	public ResponseEntity<ApiResponse<Void>> oauthRegister(
 		@RequestBody @Valid OAuthRegisterRequest oAuthRegisterRequest) {
 		authService.oauthRegister(oAuthRegisterRequest);
-		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.noContent());
+		return ResponseEntity.ok(ApiResponse.noContent());
 	}
 
 	@PostMapping("/reissue")
@@ -107,6 +107,6 @@ public class AuthController {
 		@CookieValue("Refresh-Token") final String refreshToken,
 		HttpServletResponse response) {
 		authService.reissue(refreshToken, response);
-		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.noContent());
+		return ResponseEntity.ok(ApiResponse.noContent());
 	}
 }

--- a/src/main/java/doldol_server/doldol/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/doldol_server/doldol/common/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -94,6 +95,17 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ErrorResponse<Void>> handleGeneralException(Exception e) {
 		CommonErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+		return ResponseEntity.status(errorCode.getHttpStatus())
+			.body(ErrorResponse.error(errorCode.getCode(), errorCode.getMessage()));
+	}
+
+	/**
+	 * 필수 요청 파라미터 누락 예외
+	 */
+	@ExceptionHandler(MissingServletRequestParameterException.class)
+	public ResponseEntity<ErrorResponse<Void>> handleMissingServletRequestParameterException(
+		MissingServletRequestParameterException e) {
+		CommonErrorCode errorCode = CommonErrorCode.MISSING_PARAMETER;
 		return ResponseEntity.status(errorCode.getHttpStatus())
 			.body(ErrorResponse.error(errorCode.getCode(), errorCode.getMessage()));
 	}

--- a/src/main/java/doldol_server/doldol/common/exception/errorCode/CommonErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/errorCode/CommonErrorCode.java
@@ -11,6 +11,7 @@ public enum CommonErrorCode implements ErrorCode {
     // 400
     INVALID_VALUE(HttpStatus.BAD_REQUEST, "C-001", "입력값이 올바르지 않습니다."),
     INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "C-002", "잘못된 인자입니다."),
+    MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "C-005", "필수 파라미터가 누락되었습니다."),
 
     // 500
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C-003", "서버 내부 오류가 발생했습니다."),

--- a/src/main/java/doldol_server/doldol/common/exception/errorCode/MailErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/errorCode/MailErrorCode.java
@@ -10,10 +10,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum MailErrorCode implements ErrorCode {
 
-	//400 BAD_REQUEST
+	// 400
 	MISSING_EMAIL(HttpStatus.BAD_REQUEST, "M-001", "이메일 주소가 누락되었습니다."),
 
-	//500 INTERNAL_SERVER_ERROR
+	// 500
 	EMAIL_SENDING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "M-002", "이메일 발송에 실패했습니다."),
 	;
 

--- a/src/main/java/doldol_server/doldol/common/exception/errorCode/MessageErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/errorCode/MessageErrorCode.java
@@ -1,0 +1,22 @@
+package doldol_server.doldol.common.exception.errorCode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MessageErrorCode implements ErrorCode {
+
+	// 404
+	MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "M-001", "메시지를 찾을 수 없습니다."),
+
+	// 403
+	MESSAGE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "M-002", "메시지에 접근할 권한이 없습니다."),
+	;
+
+	private HttpStatus httpStatus;
+	private String code;
+	private String message;
+}

--- a/src/main/java/doldol_server/doldol/common/exception/errorCode/UserErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/errorCode/UserErrorCode.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum UserErrorCode implements ErrorCode {
+
+	// 404
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U-001", "회원을 찾을 수 없습니다."),
 	;
 

--- a/src/main/java/doldol_server/doldol/common/request/CursorPageRequest.java
+++ b/src/main/java/doldol_server/doldol/common/request/CursorPageRequest.java
@@ -1,12 +1,14 @@
 package doldol_server.doldol.common.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 
 public record CursorPageRequest(
 	@Schema(description = "커서 페이징 기준 ID - null인 경우 첫 페이지로 간주합니다.", type = "long", example = "1")
 	Long cursorId,
 
 	@Schema(description = "가져올 데이터 개수", example = "10")
+	@Min(value = 1, message = "size는 1 이상이어야 합니다.")
 	int size
 ) {
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
@@ -1,6 +1,7 @@
 package doldol_server.doldol.rollingPaper.controller;
 
 import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,19 +15,24 @@ import org.springframework.web.bind.annotation.RestController;
 
 import doldol_server.doldol.auth.dto.CustomUserDetails;
 import doldol_server.doldol.common.response.ApiResponse;
-import doldol_server.doldol.rollingPaper.dto.request.DeleteMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.request.CreateMessageRequest;
+import doldol_server.doldol.rollingPaper.dto.request.DeleteMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.request.UpdateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.response.MessageResponse;
+import doldol_server.doldol.rollingPaper.service.MessageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @Tag(name = "메세지")
 @RestController
 @RequestMapping("/messages")
+@RequiredArgsConstructor
 public class MessageController {
+
+	private final MessageService messageService;
 
 	@GetMapping("/{id}")
 	@Operation(
@@ -45,11 +51,11 @@ public class MessageController {
 		summary = "메세지 작성 API",
 		description = "메세지 작성",
 		security = {@SecurityRequirement(name = "jwt")})
-	public ResponseEntity<ApiResponse<MessageResponse>> createMessage(
+	public ResponseEntity<ApiResponse<Void>> createMessage(
 		@RequestBody @Valid CreateMessageRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
-		MessageResponse response = null;
-		return ResponseEntity.ok(ApiResponse.created(response));
+		messageService.createMessage(request, userDetails.getUserId());
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.noContent());
 	}
 
 	@PatchMapping

--- a/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
@@ -1,26 +1,30 @@
 package doldol_server.doldol.rollingPaper.controller;
 
+import java.util.List;
+
 import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import doldol_server.doldol.auth.dto.CustomUserDetails;
+import doldol_server.doldol.common.request.CursorPageRequest;
 import doldol_server.doldol.common.response.ApiResponse;
 import doldol_server.doldol.rollingPaper.dto.request.CreateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.request.DeleteMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.request.UpdateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.response.MessageResponse;
+import doldol_server.doldol.rollingPaper.entity.MessageType;
 import doldol_server.doldol.rollingPaper.service.MessageService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -34,16 +38,20 @@ public class MessageController {
 
 	private final MessageService messageService;
 
-	@GetMapping("/{id}")
+	@GetMapping()
 	@Operation(
-		summary = "메세지 상세 조회 API",
-		description = "메세지 상세 조회",
+		summary = "메세지 리스트 조회 API",
+		description = "메세지 리스트 조회",
 		security = {@SecurityRequirement(name = "jwt")})
-	public ResponseEntity<ApiResponse<MessageResponse>> getMessage(
-		@PathVariable("id") Long messageId,
+	public ResponseEntity<ApiResponse<List<MessageResponse>>> getMessages(
+		@RequestParam("paperId") Long paperId,
+		@Parameter(description = "메시지 타입: RECEIVE(송신) 또는 SEND(발신)")
+		@RequestParam(defaultValue = "SEND") MessageType messageType,
+		@ParameterObject @Valid CursorPageRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
-		MessageResponse response = null;
-		return ResponseEntity.ok(ApiResponse.ok(response));
+		List<MessageResponse> messages = messageService.getMessages(paperId, messageType, request,
+			userDetails.getUserId());
+		return ResponseEntity.ok(ApiResponse.ok(messages));
 	}
 
 	@PostMapping

--- a/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
@@ -78,6 +78,7 @@ public class MessageController {
 	public ResponseEntity<ApiResponse<Void>> deleteMessage(
 		@ParameterObject @RequestBody @Valid DeleteMessageRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		messageService.deleteMessage(request, userDetails.getUserId());
 		return ResponseEntity.ok(ApiResponse.noContent());
 	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
@@ -66,6 +66,7 @@ public class MessageController {
 	public ResponseEntity<ApiResponse<Void>> updateMessage(
 		@RequestBody @Valid UpdateMessageRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		messageService.updateMessage(request, userDetails.getUserId());
 		return ResponseEntity.ok(ApiResponse.noContent());
 	}
 

--- a/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
@@ -55,7 +55,7 @@ public class MessageController {
 		@RequestBody @Valid CreateMessageRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		messageService.createMessage(request, userDetails.getUserId());
-		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.noContent());
+		return ResponseEntity.ok(ApiResponse.noContent());
 	}
 
 	@PatchMapping

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/request/CreateMessageRequest.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/request/CreateMessageRequest.java
@@ -22,9 +22,11 @@ public record CreateMessageRequest(
 	@Schema(description = "보내는 사람 이름", example = "돌돌")
 	String from,
 
+	@NotBlank(message = "글씨체가 입력되어야 합니다.")
 	@Schema(description = "글씨체", example = "프리텐다드")
 	String fontStyle,
 
+	@NotBlank(message = "배경 색상이 입력되어야 합니다.")
 	@Schema(description = "배경 색상", example = "#000000")
 	String backgroundColor
 ) {

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/request/CreateMessageRequest.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/request/CreateMessageRequest.java
@@ -6,6 +6,10 @@ import jakarta.validation.constraints.NotNull;
 
 @Schema(name = "CreateMessageRequest: 메세지 생성 Dto")
 public record CreateMessageRequest(
+	@NotNull(message = "롤링페이퍼 ID는 필수입니다.")
+	@Schema(description = "롤링페이퍼 ID", example = "1")
+	Long paperId,
+
 	@NotNull(message = "받는 사람 ID가 입력되어야 합니다.")
 	@Schema(description = "받는 사람 ID", example = "가나다라마바사")
 	Long receiverId,

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/request/UpdateMessageRequest.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/request/UpdateMessageRequest.java
@@ -10,6 +10,14 @@ public record UpdateMessageRequest(
 	@Schema(description = "수정할 메세지 ID", example = "1")
 	Long messageId,
 
+	@NotBlank(message = "글씨체가 입력되어야 합니다.")
+	@Schema(description = "글씨체", example = "프리텐다드")
+	String fontStyle,
+
+	@NotBlank(message = "배경 색상 입력되어야 합니다.")
+	@Schema(description = "배경 색상", example = "#000000")
+	String backgroundColor,
+
 	@NotBlank(message = "메세지 내용이 입력되어야 합니다.")
 	@Schema(description = "메세지 내용", example = "가나다라마바사")
 	String content,

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/response/MessageResponse.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/response/MessageResponse.java
@@ -2,18 +2,33 @@ package doldol_server.doldol.rollingPaper.dto.response;
 
 import java.time.LocalDateTime;
 
+import doldol_server.doldol.rollingPaper.entity.MessageType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 @Schema(name = "MessageResponse: 메세지 응답 Dto")
 public record MessageResponse(
 	@NotBlank(message = "수신/발신 여부가 입력되어야 합니다.")
 	@Schema(description = "수신/발신 여부", example = "RECEIVE/SENT")
-	String toOrFrom,
+	MessageType messageType,
 
 	@NotBlank(message = "메세지 내용이 입력되어야 합니다.")
 	@Schema(description = "메세지 내용", example = "가나다라마바사")
 	String content,
+
+	@NotBlank(message = "폰트 스타일이 있어야합니다.")
+	@Schema(description = "폰트 스타일", example = "귀여운 글씨체")
+	String fontStyle,
+
+	@NotBlank(message = "배경색이 있어야합니다.")
+	@Schema(description = "배경색", example = "검은색")
+	String backgroundColor,
+
+	@NotBlank(message = "삭제여부가 있어야합니다..")
+	@Schema(description = "삭제여부", example = "false")
+	boolean isDeleted,
 
 	@NotBlank(message = "받은/보낸 사람 이름이 입력되어야 합니다.")
 	@Schema(description = "받은/보낸 사람", example = "돌돌")
@@ -21,6 +36,9 @@ public record MessageResponse(
 
 	@NotBlank(message = "생성 날짜가 있어야 합니다.")
 	@Schema(description = "생성 날짜", example = "2025-05-26T11:44:30.327959")
-	LocalDateTime createdAt
+	LocalDateTime createdAt,
+
+	@Schema(description = "수정 날짜", example = "2025-05-27T11:44:30.327959")
+	LocalDateTime updatedAt
 ) {
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/response/MessageResponse.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/response/MessageResponse.java
@@ -2,6 +2,7 @@ package doldol_server.doldol.rollingPaper.dto.response;
 
 import java.time.LocalDateTime;
 
+import doldol_server.doldol.rollingPaper.entity.Message;
 import doldol_server.doldol.rollingPaper.entity.MessageType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -10,6 +11,10 @@ import lombok.Builder;
 @Builder
 @Schema(name = "MessageResponse: 메세지 응답 Dto")
 public record MessageResponse(
+	@NotBlank(message = "메세지 고유 id입니다.")
+	@Schema(description = "메세지 고유 id", example = "1")
+	Long messageId,
+
 	@NotBlank(message = "수신/발신 여부가 입력되어야 합니다.")
 	@Schema(description = "수신/발신 여부", example = "RECEIVE/SENT")
 	MessageType messageType,
@@ -41,4 +46,17 @@ public record MessageResponse(
 	@Schema(description = "수정 날짜", example = "2025-05-27T11:44:30.327959")
 	LocalDateTime updatedAt
 ) {
+	public static MessageResponse of(Message message, MessageType messageType) {
+		return MessageResponse.builder()
+			.messageId(message.getId())
+			.messageType(messageType)
+			.content(message.getContent())
+			.fontStyle(message.getFontStyle())
+			.backgroundColor(message.getBackgroundColor())
+			.isDeleted(message.isDeleted())
+			.name(message.getName())
+			.createdAt(message.getCreatedAt())
+			.updatedAt(message.getUpdatedAt())
+			.build();
+	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/entity/Message.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/entity/Message.java
@@ -1,6 +1,7 @@
 package doldol_server.doldol.rollingPaper.entity;
 
 import doldol_server.doldol.common.entity.BaseEntity;
+import doldol_server.doldol.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -39,10 +41,27 @@ public class Message extends BaseEntity {
 	private boolean isDeleted = false;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "from_id")
-	private Participant from;
+	@JoinColumn(name = "from_user_id")
+	private User from;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "to_id")
-	private Participant to;
+	@JoinColumn(name = "to_user_id")
+	private User to;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "paper_id")
+	private Paper paper;
+
+	@Builder
+	public Message(String backgroundColor, String content, String fontStyle, User from, boolean isDeleted, String name,
+		Paper paper, User to) {
+		this.backgroundColor = backgroundColor;
+		this.content = content;
+		this.fontStyle = fontStyle;
+		this.from = from;
+		this.isDeleted = isDeleted;
+		this.name = name;
+		this.paper = paper;
+		this.to = to;
+	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/entity/Message.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/entity/Message.java
@@ -71,4 +71,8 @@ public class Message extends BaseEntity {
 		this.fontStyle = fontStyle;
 		this.backgroundColor = backgroundColor;
 	}
+
+	public void updateDeleteStatus() {
+		this.isDeleted = true;
+	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/entity/Message.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/entity/Message.java
@@ -41,11 +41,11 @@ public class Message extends BaseEntity {
 	private boolean isDeleted = false;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "from_user_id")
+	@JoinColumn(name = "from_user_id", referencedColumnName = "user_id")
 	private User from;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "to_user_id")
+	@JoinColumn(name = "to_user_id", referencedColumnName = "user_id")
 	private User to;
 
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -63,5 +63,12 @@ public class Message extends BaseEntity {
 		this.name = name;
 		this.paper = paper;
 		this.to = to;
+	}
+
+	public void update(String fontStyle, String backgroundColor, String content, String from) {
+		this.content = content;
+		this.name = from;
+		this.fontStyle = fontStyle;
+		this.backgroundColor = backgroundColor;
 	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/repository/MessageRepository.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/repository/MessageRepository.java
@@ -3,6 +3,7 @@ package doldol_server.doldol.rollingPaper.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import doldol_server.doldol.rollingPaper.entity.Message;
+import doldol_server.doldol.rollingPaper.repository.custom.MessageRepositoryCustom;
 
-public interface MessageRepository extends JpaRepository<Message, Long> {
+public interface MessageRepository extends JpaRepository<Message, Long>, MessageRepositoryCustom {
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/repository/MessageRepository.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/repository/MessageRepository.java
@@ -1,0 +1,8 @@
+package doldol_server.doldol.rollingPaper.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import doldol_server.doldol.rollingPaper.entity.Message;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+}

--- a/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustom.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustom.java
@@ -1,0 +1,8 @@
+package doldol_server.doldol.rollingPaper.repository.custom;
+
+import doldol_server.doldol.rollingPaper.entity.Message;
+
+public interface MessageRepositoryCustom {
+
+	Message getMessage(Long messageId, Long userId);
+}

--- a/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustom.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustom.java
@@ -1,8 +1,24 @@
 package doldol_server.doldol.rollingPaper.repository.custom;
 
+import java.util.List;
+
+import doldol_server.doldol.common.request.CursorPageRequest;
+import doldol_server.doldol.rollingPaper.dto.response.MessageResponse;
 import doldol_server.doldol.rollingPaper.entity.Message;
 
 public interface MessageRepositoryCustom {
 
 	Message getMessage(Long messageId, Long userId);
+
+	List<MessageResponse> getReceivedMessages(
+		Long paperId,
+		Long userId,
+		CursorPageRequest request
+	);
+
+	List<MessageResponse> getSentMessages(
+		Long paperId,
+		Long userId,
+		CursorPageRequest request
+	);
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustomImpl.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustomImpl.java
@@ -1,0 +1,34 @@
+package doldol_server.doldol.rollingPaper.repository.custom;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import doldol_server.doldol.rollingPaper.entity.Message;
+import doldol_server.doldol.rollingPaper.entity.QMessage;
+import doldol_server.doldol.user.entity.QUser;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MessageRepositoryCustomImpl implements MessageRepositoryCustom{
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Message getMessage(Long messageId, Long userId) {
+		QMessage message = QMessage.message;
+		QUser fromUser = new QUser("fromUser");
+		QUser toUser = new QUser("toUser");
+
+		return queryFactory
+			.selectFrom(message)
+			.join(message.from, fromUser).fetchJoin()
+			.join(message.to, toUser).fetchJoin()
+			.where(
+				message.id.eq(messageId)
+					.and(
+						message.from.id.eq(userId)
+							.or(message.to.id.eq(userId))
+					)
+			)
+			.fetchOne();
+	}
+}

--- a/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustomImpl.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustomImpl.java
@@ -1,14 +1,20 @@
 package doldol_server.doldol.rollingPaper.repository.custom;
 
+import java.util.List;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import doldol_server.doldol.common.request.CursorPageRequest;
+import doldol_server.doldol.rollingPaper.dto.response.MessageResponse;
 import doldol_server.doldol.rollingPaper.entity.Message;
+import doldol_server.doldol.rollingPaper.entity.MessageType;
 import doldol_server.doldol.rollingPaper.entity.QMessage;
 import doldol_server.doldol.user.entity.QUser;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class MessageRepositoryCustomImpl implements MessageRepositoryCustom{
+public class MessageRepositoryCustomImpl implements MessageRepositoryCustom {
 
 	private final JPAQueryFactory queryFactory;
 
@@ -30,5 +36,57 @@ public class MessageRepositoryCustomImpl implements MessageRepositoryCustom{
 					)
 			)
 			.fetchOne();
+	}
+
+	@Override
+	public List<MessageResponse> getReceivedMessages(Long paperId, Long userId, CursorPageRequest request) {
+		QMessage message = QMessage.message;
+
+		BooleanExpression cursorCondition = null;
+		if (request.cursorId() != null) {
+			cursorCondition = message.id.lt(request.cursorId());
+		}
+
+		List<Message> messages = queryFactory
+			.selectFrom(message)
+			.where(
+				message.paper.id.eq(paperId),
+				message.to.id.eq(userId),
+				message.isDeleted.eq(false),
+				cursorCondition
+			)
+			.orderBy(message.id.desc())
+			.limit(request.size() + 1L)
+			.fetch();
+
+		return messages.stream()
+			.map(msg -> MessageResponse.of(msg, MessageType.RECEIVE))
+			.toList();
+	}
+
+	@Override
+	public List<MessageResponse> getSentMessages(Long paperId, Long userId, CursorPageRequest request) {
+		QMessage message = QMessage.message;
+
+		BooleanExpression cursorCondition = null;
+		if (request.cursorId() != null) {
+			cursorCondition = message.id.lt(request.cursorId());
+		}
+
+		List<Message> messages = queryFactory
+			.selectFrom(message)
+			.where(
+				message.paper.id.eq(paperId),
+				message.from.id.eq(userId),
+				message.isDeleted.eq(false),
+				cursorCondition
+			)
+			.orderBy(message.id.desc())
+			.limit(request.size() + 1L)
+			.fetch();
+
+		return messages.stream()
+			.map(msg -> MessageResponse.of(msg, MessageType.SEND))
+			.toList();
 	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/MessageService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/MessageService.java
@@ -5,8 +5,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import doldol_server.doldol.common.exception.CustomException;
 import doldol_server.doldol.common.exception.errorCode.AuthErrorCode;
+import doldol_server.doldol.common.exception.errorCode.MessageErrorCode;
 import doldol_server.doldol.common.exception.errorCode.PaperErrorCode;
 import doldol_server.doldol.rollingPaper.dto.request.CreateMessageRequest;
+import doldol_server.doldol.rollingPaper.dto.request.UpdateMessageRequest;
 import doldol_server.doldol.rollingPaper.entity.Message;
 import doldol_server.doldol.rollingPaper.entity.Paper;
 import doldol_server.doldol.rollingPaper.repository.MessageRepository;
@@ -47,5 +49,16 @@ public class MessageService {
 			.build();
 
 		messageRepository.save(message);
+	}
+
+	@Transactional
+	public void updateMessage(UpdateMessageRequest request, Long userId) {
+		Message message = messageRepository.getMessage(request.messageId(), userId);
+
+		if (message == null) {
+			throw new CustomException(MessageErrorCode.MESSAGE_NOT_FOUND);
+		}
+
+		message.update(request.fontStyle(), request.backgroundColor(), request.content(), request.from());
 	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/MessageService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/MessageService.java
@@ -24,6 +24,7 @@ public class MessageService {
 	private final MessageRepository messageRepository;
 	private final UserRepository userRepository;
 
+	@Transactional
 	public void createMessage(CreateMessageRequest request, Long userId) {
 
 		User fromUser = userRepository.findById(userId)

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/MessageService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/MessageService.java
@@ -1,5 +1,7 @@
 package doldol_server.doldol.rollingPaper.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -7,10 +9,13 @@ import doldol_server.doldol.common.exception.CustomException;
 import doldol_server.doldol.common.exception.errorCode.AuthErrorCode;
 import doldol_server.doldol.common.exception.errorCode.MessageErrorCode;
 import doldol_server.doldol.common.exception.errorCode.PaperErrorCode;
+import doldol_server.doldol.common.request.CursorPageRequest;
 import doldol_server.doldol.rollingPaper.dto.request.CreateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.request.DeleteMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.request.UpdateMessageRequest;
+import doldol_server.doldol.rollingPaper.dto.response.MessageResponse;
 import doldol_server.doldol.rollingPaper.entity.Message;
+import doldol_server.doldol.rollingPaper.entity.MessageType;
 import doldol_server.doldol.rollingPaper.entity.Paper;
 import doldol_server.doldol.rollingPaper.repository.MessageRepository;
 import doldol_server.doldol.rollingPaper.repository.PaperRepository;
@@ -26,6 +31,14 @@ public class MessageService {
 	private final PaperRepository paperRepository;
 	private final MessageRepository messageRepository;
 	private final UserRepository userRepository;
+
+	public List<MessageResponse> getMessages(Long paperId, MessageType messageType, CursorPageRequest request,
+		Long userId) {
+		if (messageType == MessageType.RECEIVE) {
+			return messageRepository.getReceivedMessages(paperId, userId, request);
+		}
+		return messageRepository.getSentMessages(paperId, userId, request);
+	}
 
 	@Transactional
 	public void createMessage(CreateMessageRequest request, Long userId) {

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/MessageService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/MessageService.java
@@ -1,0 +1,50 @@
+package doldol_server.doldol.rollingPaper.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import doldol_server.doldol.common.exception.CustomException;
+import doldol_server.doldol.common.exception.errorCode.AuthErrorCode;
+import doldol_server.doldol.common.exception.errorCode.PaperErrorCode;
+import doldol_server.doldol.rollingPaper.dto.request.CreateMessageRequest;
+import doldol_server.doldol.rollingPaper.entity.Message;
+import doldol_server.doldol.rollingPaper.entity.Paper;
+import doldol_server.doldol.rollingPaper.repository.MessageRepository;
+import doldol_server.doldol.rollingPaper.repository.PaperRepository;
+import doldol_server.doldol.user.entity.User;
+import doldol_server.doldol.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MessageService {
+
+	private final PaperRepository paperRepository;
+	private final MessageRepository messageRepository;
+	private final UserRepository userRepository;
+
+	public void createMessage(CreateMessageRequest request, Long userId) {
+
+		User fromUser = userRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+		User toUser = userRepository.findById(request.receiverId())
+			.orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+		Paper paper = paperRepository.findById(request.paperId())
+			.orElseThrow(() -> new CustomException(PaperErrorCode.PAPER_NOT_FOUND));
+
+		Message message = Message.builder()
+			.to(toUser)
+			.from(fromUser)
+			.paper(paper)
+			.name(request.from())
+			.backgroundColor(request.backgroundColor())
+			.content(request.content())
+			.fontStyle(request.fontStyle())
+			.build();
+
+		messageRepository.save(message);
+	}
+}

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/MessageService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/MessageService.java
@@ -8,6 +8,7 @@ import doldol_server.doldol.common.exception.errorCode.AuthErrorCode;
 import doldol_server.doldol.common.exception.errorCode.MessageErrorCode;
 import doldol_server.doldol.common.exception.errorCode.PaperErrorCode;
 import doldol_server.doldol.rollingPaper.dto.request.CreateMessageRequest;
+import doldol_server.doldol.rollingPaper.dto.request.DeleteMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.request.UpdateMessageRequest;
 import doldol_server.doldol.rollingPaper.entity.Message;
 import doldol_server.doldol.rollingPaper.entity.Paper;
@@ -60,5 +61,16 @@ public class MessageService {
 		}
 
 		message.update(request.fontStyle(), request.backgroundColor(), request.content(), request.from());
+	}
+
+	@Transactional
+	public void deleteMessage(DeleteMessageRequest request, Long userId) {
+		Message message = messageRepository.getMessage(request.messageId(), userId);
+
+		if (message == null) {
+			throw new CustomException(MessageErrorCode.MESSAGE_NOT_FOUND);
+		}
+
+		message.updateDeleteStatus();
 	}
 }

--- a/src/test/java/doldol_server/doldol/auth/controller/AuthControllerTest.java
+++ b/src/test/java/doldol_server/doldol/auth/controller/AuthControllerTest.java
@@ -39,7 +39,7 @@ class AuthControllerTest extends ControllerTest {
 		mockMvc.perform(post("/auth/check-id")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(asJsonString(request)))
-			.andExpect(status().isNoContent());
+			.andExpect(status().isOk());
 
 		verify(authService).checkIdDuplicate("test");
 	}
@@ -55,7 +55,7 @@ class AuthControllerTest extends ControllerTest {
 		mockMvc.perform(post("/auth/check-email")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(asJsonString(request)))
-			.andExpect(status().isNoContent());
+			.andExpect(status().isOk());
 
 		verify(authService).checkEmailDuplicate("test@example.com");
 	}
@@ -71,7 +71,7 @@ class AuthControllerTest extends ControllerTest {
 		mockMvc.perform(post("/auth/check-phone")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(asJsonString(request)))
-			.andExpect(status().isNoContent());
+			.andExpect(status().isOk());
 
 		verify(authService).checkPhoneDuplicate("01001010101");
 	}
@@ -117,7 +117,7 @@ class AuthControllerTest extends ControllerTest {
 		mockMvc.perform(post("/auth/email/verify-code")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(asJsonString(request)))
-			.andExpect(status().isNoContent());
+			.andExpect(status().isOk());
 
 		verify(authService).validateVerificationCode("test@example.com", "123456");
 	}
@@ -139,7 +139,7 @@ class AuthControllerTest extends ControllerTest {
 		mockMvc.perform(post("/auth/register")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(asJsonString(request)))
-			.andExpect(status().isNoContent());
+			.andExpect(status().isOk());
 
 		verify(authService).register(any(RegisterRequest.class));
 	}
@@ -161,7 +161,7 @@ class AuthControllerTest extends ControllerTest {
 		mockMvc.perform(post("/auth/oauth/register")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(asJsonString(request)))
-			.andExpect(status().isNoContent());
+			.andExpect(status().isOk());
 
 		verify(authService).oauthRegister(any(OAuthRegisterRequest.class));
 	}
@@ -365,7 +365,7 @@ class AuthControllerTest extends ControllerTest {
 		// when & then
 		mockMvc.perform(post("/auth/reissue")
 				.cookie(new Cookie("Refresh-Token", refreshToken)))
-			.andExpect(status().isNoContent());
+			.andExpect(status().isOk());
 
 		verify(authService).reissue(eq(refreshToken), any(HttpServletResponse.class));
 	}

--- a/src/test/java/doldol_server/doldol/common/ControllerTest.java
+++ b/src/test/java/doldol_server/doldol/common/ControllerTest.java
@@ -1,12 +1,21 @@
 package doldol_server.doldol.common;
 
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import doldol_server.doldol.auth.dto.CustomUserDetails;
 import doldol_server.doldol.common.config.TestSecurityConfig;
 
 @Import(TestSecurityConfig.class)
@@ -25,5 +34,16 @@ public abstract class ControllerTest {
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	protected RequestPostProcessor mockUser(Long userId) {
+		CustomUserDetails userDetails = mock(CustomUserDetails.class);
+		when(userDetails.getUserId()).thenReturn(userId);
+
+		Authentication auth = new UsernamePasswordAuthenticationToken(
+			userDetails, null, List.of()
+		);
+
+		return authentication(auth);
 	}
 }

--- a/src/test/java/doldol_server/doldol/common/RepositoryTest.java
+++ b/src/test/java/doldol_server/doldol/common/RepositoryTest.java
@@ -1,0 +1,15 @@
+package doldol_server.doldol.common;
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.ActiveProfiles;
+
+import doldol_server.doldol.common.config.QueryDslConfig;
+
+@EnableJpaAuditing
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(QueryDslConfig.class)
+public abstract class RepositoryTest {
+}

--- a/src/test/java/doldol_server/doldol/rollingPaper/controller/MessageControllerTest.java
+++ b/src/test/java/doldol_server/doldol/rollingPaper/controller/MessageControllerTest.java
@@ -1,0 +1,247 @@
+package doldol_server.doldol.rollingPaper.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import doldol_server.doldol.common.ControllerTest;
+import doldol_server.doldol.rollingPaper.dto.request.CreateMessageRequest;
+import doldol_server.doldol.rollingPaper.dto.request.DeleteMessageRequest;
+import doldol_server.doldol.rollingPaper.dto.request.UpdateMessageRequest;
+import doldol_server.doldol.rollingPaper.dto.response.MessageResponse;
+import doldol_server.doldol.rollingPaper.entity.MessageType;
+import doldol_server.doldol.rollingPaper.service.MessageService;
+
+@WebMvcTest(controllers = MessageController.class)
+class MessageControllerTest extends ControllerTest {
+
+	@MockitoBean
+	private MessageService messageService;
+
+	@Test
+	@DisplayName("받은 메시지 목록 조회 - 성공")
+	void getMessages_Receive_Success() throws Exception {
+		// given
+		List<MessageResponse> mockMessages = List.of(
+			MessageResponse.builder()
+				.messageType(MessageType.RECEIVE)
+				.content("안녕하세요!")
+				.fontStyle("Arial")
+				.backgroundColor("#FFFFFF")
+				.isDeleted(false)
+				.name("김철수")
+				.createdAt(LocalDateTime.now())
+				.updatedAt(LocalDateTime.now())
+				.build()
+		);
+
+		when(messageService.getMessages(anyLong(), any(MessageType.class), any(), anyLong()))
+			.thenReturn(mockMessages);
+
+		// when & then
+		mockMvc.perform(get("/messages")
+				.param("paperId", "1")
+				.param("messageType", "RECEIVE")
+				.param("size", "10")
+				.with(mockUser(1L)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data").isArray())
+			.andExpect(jsonPath("$.data[0].messageType").value("RECEIVE"))
+			.andExpect(jsonPath("$.data[0].content").value("안녕하세요!"))
+			.andExpect(jsonPath("$.status").value(200));
+
+		verify(messageService).getMessages(eq(1L), eq(MessageType.RECEIVE), any(), anyLong());
+	}
+
+	@Test
+	@DisplayName("보낸 메시지 목록 조회 - 성공 (기본값 SEND)")
+	void getMessages_Send_Success() throws Exception {
+		// given
+		List<MessageResponse> mockMessages = List.of(
+			MessageResponse.builder()
+				.messageType(MessageType.SEND)
+				.content("잘 지내세요!")
+				.fontStyle("Georgia")
+				.backgroundColor("#F0F0F0")
+				.isDeleted(false)
+				.name("이영희")
+				.createdAt(LocalDateTime.now())
+				.updatedAt(LocalDateTime.now())
+				.build()
+		);
+
+		when(messageService.getMessages(anyLong(), any(MessageType.class), any(), anyLong()))
+			.thenReturn(mockMessages);
+
+		// when & then
+		mockMvc.perform(get("/messages")
+				.param("paperId", "1")
+				.param("size", "10")
+				.with(mockUser(1L)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data").isArray())
+			.andExpect(jsonPath("$.data[0].messageType").value("SEND"));
+
+		verify(messageService).getMessages(eq(1L), eq(MessageType.SEND), any(), anyLong());
+	}
+
+	@Test
+	@DisplayName("커서 페이징을 사용한 메시지 목록 조회 - 성공")
+	void getMessages_WithCursor_Success() throws Exception {
+		// given
+		List<MessageResponse> mockMessages = List.of();
+		when(messageService.getMessages(anyLong(), any(MessageType.class), any(), anyLong()))
+			.thenReturn(mockMessages);
+
+		// when & then
+		mockMvc.perform(get("/messages")
+				.param("paperId", "1")
+				.param("messageType", "RECEIVE")
+				.param("cursorId", "10")
+				.param("size", "5")
+				.with(mockUser(1L)))
+			.andExpect(status().isOk());
+
+		verify(messageService).getMessages(eq(1L), eq(MessageType.RECEIVE), any(), anyLong());
+	}
+
+	@Test
+	@DisplayName("메시지 작성 - 성공")
+	void createMessage_Success() throws Exception {
+		// given
+		CreateMessageRequest request = new CreateMessageRequest(
+			1L, 2L, "안녕하세요!", "Arial", "#FFFFFF", "김철수"
+		);
+		doNothing().when(messageService).createMessage(any(CreateMessageRequest.class), anyLong());
+
+		// when & then
+		mockMvc.perform(post("/messages")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request))
+				.with(mockUser(1L)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(204));
+
+		verify(messageService).createMessage(any(CreateMessageRequest.class), anyLong());
+	}
+
+	@Test
+	@DisplayName("메시지 작성 - 내용 비어있으면 오류를 발생시킵니다.")
+	void createMessage_ValidationFail_ContentBlank() throws Exception {
+		// given
+		CreateMessageRequest request = new CreateMessageRequest(
+			1L, 2L, "", "Arial", "#FFFFFF", "김철수"
+		);
+
+		// when & then
+		mockMvc.perform(post("/messages")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request)))
+			.andExpect(status().isBadRequest());
+
+		verify(messageService, never()).createMessage(any(CreateMessageRequest.class), anyLong());
+	}
+
+	@Test
+	@DisplayName("메시지 수정 - 성공")
+	void updateMessage_Success() throws Exception {
+		// given
+		UpdateMessageRequest request = new UpdateMessageRequest(
+			1L, "수정된 내용", "Georgia", "#F0F0F0", "김철수"
+		);
+		doNothing().when(messageService).updateMessage(any(UpdateMessageRequest.class), anyLong());
+
+		// when & then
+		mockMvc.perform(patch("/messages")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request))
+				.with(mockUser(1L)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(204));
+
+		verify(messageService).updateMessage(any(UpdateMessageRequest.class), anyLong());
+	}
+
+	@Test
+	@DisplayName("메시지 수정 - 메시지 ID가 null이면 오류를 발생시킵니다.")
+	void updateMessage_ValidationFail_MessageIdNull() throws Exception {
+		// given
+		UpdateMessageRequest request = new UpdateMessageRequest(
+			null, "수정된 내용", "Georgia", "#F0F0F0", "김철수"
+		);
+
+		// when & then
+		mockMvc.perform(patch("/messages")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request)))
+			.andExpect(status().isBadRequest());
+
+		verify(messageService, never()).updateMessage(any(UpdateMessageRequest.class), anyLong());
+	}
+
+	@Test
+	@DisplayName("메시지 삭제 - 성공")
+	void deleteMessage_Success() throws Exception {
+		// given
+		DeleteMessageRequest request = new DeleteMessageRequest(1L);
+		doNothing().when(messageService).deleteMessage(any(DeleteMessageRequest.class), anyLong());
+
+		// when & then
+		mockMvc.perform(delete("/messages")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request))
+				.with(mockUser(1L)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(204));
+
+		verify(messageService).deleteMessage(any(DeleteMessageRequest.class), anyLong());
+	}
+
+	@Test
+	@DisplayName("메시지 삭제 - 메시지 ID가 null이면 오류를 발생시킵니다.")
+	void deleteMessage_ValidationFail_MessageIdNull() throws Exception {
+		// given
+		DeleteMessageRequest request = new DeleteMessageRequest(null);
+
+		// when & then
+		mockMvc.perform(delete("/messages")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request)))
+			.andExpect(status().isBadRequest());
+
+		verify(messageService, never()).deleteMessage(any(DeleteMessageRequest.class), anyLong());
+	}
+
+	@Test
+	@DisplayName("메시지 목록 조회 - paperId 누락이면 오류를 발생시킵니다.")
+	void getMessages_ValidationFail_PaperIdMissing() throws Exception {
+		// when & then
+		mockMvc.perform(get("/messages")
+				.param("size", "10"))
+			.andExpect(status().isBadRequest());
+
+		verify(messageService, never()).getMessages(anyLong(), any(MessageType.class), any(), anyLong());
+	}
+
+	@Test
+	@DisplayName("메시지 목록 조회 - size가 0 이하이면 오류를 발생시킵니다.")
+	void getMessages_ValidationFail_InvalidSize() throws Exception {
+		// when & then
+		mockMvc.perform(get("/messages")
+				.param("paperId", "1")
+				.param("size", "0"))
+			.andExpect(status().isBadRequest());
+
+		verify(messageService, never()).getMessages(anyLong(), any(MessageType.class), any(), anyLong());
+	}
+}

--- a/src/test/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustomImplTest.java
+++ b/src/test/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustomImplTest.java
@@ -1,0 +1,512 @@
+package doldol_server.doldol.rollingPaper.repository.custom;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import doldol_server.doldol.common.RepositoryTest;
+import doldol_server.doldol.common.request.CursorPageRequest;
+import doldol_server.doldol.rollingPaper.dto.response.MessageResponse;
+import doldol_server.doldol.rollingPaper.entity.Message;
+import doldol_server.doldol.rollingPaper.entity.MessageType;
+import doldol_server.doldol.rollingPaper.entity.Paper;
+import doldol_server.doldol.rollingPaper.repository.MessageRepository;
+import doldol_server.doldol.rollingPaper.repository.PaperRepository;
+import doldol_server.doldol.user.entity.User;
+import doldol_server.doldol.user.repository.UserRepository;
+
+@DisplayName("MessageRepositoryCustomImpl 테스트")
+class MessageRepositoryCustomImplTest extends RepositoryTest {
+
+	@Autowired
+	private JPAQueryFactory queryFactory;
+
+	@Autowired
+	private MessageRepository messageRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private PaperRepository paperRepository;
+
+	private MessageRepositoryCustomImpl messageRepositoryCustom;
+
+	private User fromUser;
+	private User toUser;
+	private User otherUser;
+	private Paper paper;
+	private Paper otherPaper;
+
+	private User createAndSaveUser(String loginId, String name, String email, String phone, String password) {
+		User user = User.builder()
+			.loginId(loginId)
+			.name(name)
+			.email(email)
+			.phone(phone)
+			.password(password)
+			.build();
+		return userRepository.save(user);
+	}
+
+	@BeforeEach
+	void setUp() {
+		messageRepositoryCustom = new MessageRepositoryCustomImpl(queryFactory);
+
+		fromUser = createAndSaveUser("sender", "김철수", "sender@test.com", "01012345678", "password123");
+		toUser = createAndSaveUser("receiver", "이영희", "receiver@test.com", "01087654321", "password456");
+		otherUser = createAndSaveUser("other", "박민수", "other@test.com", "01011111111", "password789");
+
+		paper = Paper.builder()
+			.name("테스트 페이퍼")
+			.description("테스트 설명")
+			.openDate(LocalDateTime.now().plusDays(1))
+			.invitationCode("ABC123")
+			.build();
+		paper = paperRepository.save(paper);
+
+		otherPaper = Paper.builder()
+			.name("다른 페이퍼")
+			.description("다른 설명")
+			.openDate(LocalDateTime.now().plusDays(2))
+			.invitationCode("XYZ789")
+			.build();
+		otherPaper = paperRepository.save(otherPaper);
+	}
+
+	@Test
+	@DisplayName("메시지 조회 - 발신자로 조회 성공")
+	void getMessage_FromUser_Success() {
+		// given
+		Message savedMessage = Message.builder()
+			.name("김철수")
+			.content("테스트 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		savedMessage = messageRepository.save(savedMessage);
+
+		// when
+		Message result = messageRepositoryCustom.getMessage(savedMessage.getId(), fromUser.getId());
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getId()).isEqualTo(savedMessage.getId());
+		assertThat(result.getContent()).isEqualTo("테스트 메시지");
+		assertThat(result.getFrom().getId()).isEqualTo(fromUser.getId());
+		assertThat(result.getTo().getId()).isEqualTo(toUser.getId());
+	}
+
+	@Test
+	@DisplayName("메시지 조회 - 수신자로 조회 성공")
+	void getMessage_ToUser_Success() {
+		// given
+		Message savedMessage = Message.builder()
+			.name("김철수")
+			.content("테스트 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		savedMessage = messageRepository.save(savedMessage);
+
+		// when
+		Message result = messageRepositoryCustom.getMessage(savedMessage.getId(), toUser.getId());
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getId()).isEqualTo(savedMessage.getId());
+		assertThat(result.getFrom().getId()).isEqualTo(fromUser.getId());
+		assertThat(result.getTo().getId()).isEqualTo(toUser.getId());
+	}
+
+	@Test
+	@DisplayName("받은 메시지 목록 조회 - 성공")
+	void getReceivedMessages_Success() {
+		// given
+		Message message1 = Message.builder()
+			.name("김철수")
+			.content("첫 번째 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(message1);
+
+		Message message2 = Message.builder()
+			.name("박민수")
+			.content("두 번째 메시지")
+			.fontStyle("Georgia")
+			.backgroundColor("#F0F0F0")
+			.from(otherUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(message2);
+
+		CursorPageRequest request = new CursorPageRequest(null, 10);
+
+		// when
+		List<MessageResponse> result = messageRepositoryCustom.getReceivedMessages(paper.getId(), toUser.getId(), request);
+
+		// then
+		assertThat(result).hasSize(2);
+		assertThat(result.get(0).messageType()).isEqualTo(MessageType.RECEIVE);
+		assertThat(result.get(1).messageType()).isEqualTo(MessageType.RECEIVE);
+
+		assertThat(result.get(0).messageId()).isGreaterThan(result.get(1).messageId());
+	}
+
+	@Test
+	@DisplayName("받은 메시지 목록 조회 - 커서 페이징")
+	void getReceivedMessages_WithCursor_Success() {
+		// given
+		Message message1 = Message.builder()
+			.name("김철수")
+			.content("첫 번째 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		message1 = messageRepository.save(message1);
+
+		Message message2 = Message.builder()
+			.name("박민수")
+			.content("두 번째 메시지")
+			.fontStyle("Georgia")
+			.backgroundColor("#F0F0F0")
+			.from(otherUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		message2 = messageRepository.save(message2);
+
+		CursorPageRequest request = new CursorPageRequest(message2.getId(), 10);
+
+		// when
+		List<MessageResponse> result = messageRepositoryCustom.getReceivedMessages(paper.getId(), toUser.getId(), request);
+
+		// then
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).messageId()).isEqualTo(message1.getId());
+		assertThat(result.get(0).content()).isEqualTo("첫 번째 메시지");
+	}
+
+	@Test
+	@DisplayName("받은 메시지 목록 조회 - 삭제된 메시지 제외")
+	void getReceivedMessages_ExcludeDeletedMessages() {
+		// given
+		Message normalMessage = Message.builder()
+			.name("김철수")
+			.content("정상 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(normalMessage);
+
+		Message deletedMessage = Message.builder()
+			.name("박민수")
+			.content("삭제된 메시지")
+			.fontStyle("Georgia")
+			.backgroundColor("#F0F0F0")
+			.from(otherUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		deletedMessage.updateDeleteStatus();
+		messageRepository.save(deletedMessage);
+
+		CursorPageRequest request = new CursorPageRequest(null, 10);
+
+		// when
+		List<MessageResponse> result = messageRepositoryCustom.getReceivedMessages(paper.getId(), toUser.getId(), request);
+
+		// then
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).content()).isEqualTo("정상 메시지");
+		assertThat(result.get(0).isDeleted()).isFalse();
+	}
+
+	@Test
+	@DisplayName("받은 메시지 목록 조회 - 다른 페이퍼의 메시지 제외")
+	void getReceivedMessages_ExcludeOtherPaperMessages() {
+		// given
+		Message messageInTargetPaper = Message.builder()
+			.name("김철수")
+			.content("대상 페이퍼 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(messageInTargetPaper);
+
+		Message messageInOtherPaper = Message.builder()
+			.name("박민수")
+			.content("다른 페이퍼 메시지")
+			.fontStyle("Georgia")
+			.backgroundColor("#F0F0F0")
+			.from(otherUser)
+			.to(toUser)
+			.paper(otherPaper)
+			.build();
+		messageRepository.save(messageInOtherPaper);
+
+		CursorPageRequest request = new CursorPageRequest(null, 10);
+
+		// when
+		List<MessageResponse> result = messageRepositoryCustom.getReceivedMessages(paper.getId(), toUser.getId(), request);
+
+		// then
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).content()).isEqualTo("대상 페이퍼 메시지");
+	}
+
+	@Test
+	@DisplayName("받은 메시지 목록 조회 - 빈 결과")
+	void getReceivedMessages_EmptyResult() {
+		// given
+		CursorPageRequest request = new CursorPageRequest(null, 10);
+
+		// when
+		List<MessageResponse> result = messageRepositoryCustom.getReceivedMessages(paper.getId(), toUser.getId(), request);
+
+		// then
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("보낸 메시지 목록 조회 - 성공")
+	void getSentMessages_Success() {
+		// given
+		Message message1 = Message.builder()
+			.name("김철수")
+			.content("첫 번째 보낸 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(message1);
+
+		Message message2 = Message.builder()
+			.name("김철수")
+			.content("두 번째 보낸 메시지")
+			.fontStyle("Georgia")
+			.backgroundColor("#F0F0F0")
+			.from(fromUser)
+			.to(otherUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(message2);
+
+		CursorPageRequest request = new CursorPageRequest(null, 10);
+
+		// when
+		List<MessageResponse> result = messageRepositoryCustom.getSentMessages(paper.getId(), fromUser.getId(), request);
+
+		// then
+		assertThat(result).hasSize(2);
+		assertThat(result.get(0).messageType()).isEqualTo(MessageType.SEND);
+		assertThat(result.get(1).messageType()).isEqualTo(MessageType.SEND);
+
+		assertThat(result.get(0).messageId()).isGreaterThan(result.get(1).messageId());
+	}
+
+	@Test
+	@DisplayName("보낸 메시지 목록 조회 - 커서 페이징")
+	void getSentMessages_WithCursor_Success() {
+		// given
+		Message message1 = Message.builder()
+			.name("김철수")
+			.content("첫 번째 보낸 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		message1 = messageRepository.save(message1);
+
+		Message message2 = Message.builder()
+			.name("김철수")
+			.content("두 번째 보낸 메시지")
+			.fontStyle("Georgia")
+			.backgroundColor("#F0F0F0")
+			.from(fromUser)
+			.to(otherUser)
+			.paper(paper)
+			.build();
+		message2 = messageRepository.save(message2);
+
+		CursorPageRequest request = new CursorPageRequest(message2.getId(), 10);
+
+		// when
+		List<MessageResponse> result = messageRepositoryCustom.getSentMessages(paper.getId(), fromUser.getId(), request);
+
+		// then
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).messageId()).isEqualTo(message1.getId());
+		assertThat(result.get(0).content()).isEqualTo("첫 번째 보낸 메시지");
+	}
+
+	@Test
+	@DisplayName("보낸 메시지 목록 조회 - 삭제된 메시지 제외")
+	void getSentMessages_ExcludeDeletedMessages() {
+		// given
+		Message normalMessage = Message.builder()
+			.name("김철수")
+			.content("정상 보낸 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(normalMessage);
+
+		Message deletedMessage = Message.builder()
+			.name("김철수")
+			.content("삭제된 보낸 메시지")
+			.fontStyle("Georgia")
+			.backgroundColor("#F0F0F0")
+			.from(fromUser)
+			.to(otherUser)
+			.paper(paper)
+			.build();
+		deletedMessage.updateDeleteStatus();
+		messageRepository.save(deletedMessage);
+
+		CursorPageRequest request = new CursorPageRequest(null, 10);
+
+		// when
+		List<MessageResponse> result = messageRepositoryCustom.getSentMessages(paper.getId(), fromUser.getId(), request);
+
+		// then
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).content()).isEqualTo("정상 보낸 메시지");
+		assertThat(result.get(0).isDeleted()).isFalse();
+	}
+
+	@Test
+	@DisplayName("보낸 메시지 목록 조회 - 다른 사용자가 보낸 메시지 제외")
+	void getSentMessages_ExcludeOtherUserMessages() {
+		// given
+		Message myMessage = Message.builder()
+			.name("김철수")
+			.content("내가 보낸 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(myMessage);
+
+		Message otherUserMessage = Message.builder()
+			.name("박민수")
+			.content("다른 사용자가 보낸 메시지")
+			.fontStyle("Georgia")
+			.backgroundColor("#F0F0F0")
+			.from(otherUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(otherUserMessage);
+
+		CursorPageRequest request = new CursorPageRequest(null, 10);
+
+		// when
+		List<MessageResponse> result = messageRepositoryCustom.getSentMessages(paper.getId(), fromUser.getId(), request);
+
+		// then
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).content()).isEqualTo("내가 보낸 메시지");
+	}
+
+	@Test
+	@DisplayName("보낸 메시지 목록 조회 - 빈 결과")
+	void getSentMessages_EmptyResult() {
+		// given
+		CursorPageRequest request = new CursorPageRequest(null, 10);
+
+		// when
+		List<MessageResponse> result = messageRepositoryCustom.getSentMessages(paper.getId(), fromUser.getId(), request);
+
+		// then
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("메시지 목록 조회 - 페이지 크기 제한 확인")
+	void getMessages_PageSizeLimit() {
+		// given
+		for (int i = 1; i <= 5; i++) {
+			final int index = i;
+			Message message = Message.builder()
+				.name("발신자" + index)
+				.content("메시지 내용 " + index)
+				.fontStyle("Arial")
+				.backgroundColor("#FFFFFF")
+				.from(fromUser)
+				.to(toUser)
+				.paper(paper)
+				.build();
+			messageRepository.save(message);
+		}
+
+		CursorPageRequest request = new CursorPageRequest(null, 3);
+
+		// when
+		List<MessageResponse> result = messageRepositoryCustom.getReceivedMessages(paper.getId(), toUser.getId(), request);
+
+		// then
+		assertThat(result).hasSize(4);
+	}
+
+	@Test
+	@DisplayName("fetchJoin 동작 확인 - N+1 문제 방지")
+	void getMessage_FetchJoin_Success() {
+		// given
+		Message savedMessage = Message.builder()
+			.name("김철수")
+			.content("테스트 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		savedMessage = messageRepository.save(savedMessage);
+
+		// when
+		Message result = messageRepositoryCustom.getMessage(savedMessage.getId(), fromUser.getId());
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getFrom().getName()).isEqualTo("김철수");
+		assertThat(result.getTo().getName()).isEqualTo("이영희");
+	}
+}

--- a/src/test/java/doldol_server/doldol/rollingPaper/service/MessageServiceTest.java
+++ b/src/test/java/doldol_server/doldol/rollingPaper/service/MessageServiceTest.java
@@ -1,0 +1,358 @@
+package doldol_server.doldol.rollingPaper.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import doldol_server.doldol.common.ServiceTest;
+import doldol_server.doldol.common.exception.CustomException;
+import doldol_server.doldol.common.exception.errorCode.AuthErrorCode;
+import doldol_server.doldol.common.exception.errorCode.MessageErrorCode;
+import doldol_server.doldol.common.exception.errorCode.PaperErrorCode;
+import doldol_server.doldol.common.request.CursorPageRequest;
+import doldol_server.doldol.rollingPaper.dto.request.CreateMessageRequest;
+import doldol_server.doldol.rollingPaper.dto.request.DeleteMessageRequest;
+import doldol_server.doldol.rollingPaper.dto.request.UpdateMessageRequest;
+import doldol_server.doldol.rollingPaper.dto.response.MessageResponse;
+import doldol_server.doldol.rollingPaper.entity.Message;
+import doldol_server.doldol.rollingPaper.entity.MessageType;
+import doldol_server.doldol.rollingPaper.entity.Paper;
+import doldol_server.doldol.rollingPaper.repository.MessageRepository;
+import doldol_server.doldol.rollingPaper.repository.PaperRepository;
+import doldol_server.doldol.user.entity.User;
+import doldol_server.doldol.user.repository.UserRepository;
+
+@DisplayName("Message 서비스 통합 테스트")
+class MessageServiceIntegrationTest extends ServiceTest {
+
+	@Autowired
+	private MessageService messageService;
+
+	@Autowired
+	private MessageRepository messageRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private PaperRepository paperRepository;
+
+	private User fromUser;
+	private User toUser;
+	private Paper paper;
+	private Message savedMessage;
+
+	private User createAndSaveUser(String loginId, String name, String email, String phone, String password) {
+		User user = User.builder()
+			.loginId(loginId)
+			.name(name)
+			.email(email)
+			.phone(phone)
+			.password(password)
+			.build();
+		return userRepository.save(user);
+	}
+
+	@BeforeEach
+	void setUp() {
+		fromUser = createAndSaveUser("sender", "김철수", "sender@test.com", "01012345678", "password123");
+		toUser = createAndSaveUser("receiver", "이영희", "receiver@test.com", "01087654321", "password456");
+
+		paper = Paper.builder()
+			.name("테스트 페이퍼")
+			.description("테스트 설명")
+			.openDate(LocalDateTime.now().plusDays(1))
+			.invitationCode("ABC123")
+			.build();
+		paper = paperRepository.save(paper);
+
+		savedMessage = Message.builder()
+			.name("김철수")
+			.content("테스트 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		savedMessage = messageRepository.save(savedMessage);
+	}
+
+	@Test
+	@DisplayName("받은 메시지 목록 조회 - 성공")
+	void getMessages_Receive_Success() {
+		// given
+		CursorPageRequest request = new CursorPageRequest(null, 10);
+
+		// when
+		List<MessageResponse> result = messageService.getMessages(
+			paper.getId(), MessageType.RECEIVE, request, toUser.getId()
+		);
+
+		// then
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).messageType()).isEqualTo(MessageType.RECEIVE);
+		assertThat(result.get(0).content()).isEqualTo("테스트 메시지");
+		assertThat(result.get(0).name()).isEqualTo("김철수");
+		assertThat(result.get(0).fontStyle()).isEqualTo("Arial");
+		assertThat(result.get(0).backgroundColor()).isEqualTo("#FFFFFF");
+		assertThat(result.get(0).isDeleted()).isFalse();
+	}
+
+	@Test
+	@DisplayName("보낸 메시지 목록 조회 - 성공")
+	void getMessages_Send_Success() {
+		// given
+		CursorPageRequest request = new CursorPageRequest(null, 10);
+
+		// when
+		List<MessageResponse> result = messageService.getMessages(
+			paper.getId(), MessageType.SEND, request, fromUser.getId()
+		);
+
+		// then
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).messageType()).isEqualTo(MessageType.SEND);
+		assertThat(result.get(0).content()).isEqualTo("테스트 메시지");
+		assertThat(result.get(0).name()).isEqualTo("김철수");
+	}
+
+	@Test
+	@DisplayName("커서 페이징을 사용한 메시지 목록 조회 - 성공")
+	void getMessages_WithCursor_Success() {
+		// given
+		Message newMessage = Message.builder()
+			.name("이영희")
+			.content("새로운 메시지")
+			.fontStyle("Georgia")
+			.backgroundColor("#F0F0F0")
+			.from(toUser)
+			.to(fromUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(newMessage);
+
+		CursorPageRequest request = new CursorPageRequest(newMessage.getId(), 10);
+
+		// when
+		List<MessageResponse> result = messageService.getMessages(
+			paper.getId(), MessageType.RECEIVE, request, toUser.getId()
+		);
+
+		// then
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).content()).isEqualTo("테스트 메시지");
+	}
+
+	@Test
+	@DisplayName("메시지 목록 조회 - 빈 결과")
+	void getMessages_EmptyResult() {
+		// given
+		CursorPageRequest request = new CursorPageRequest(null, 10);
+		Long nonExistentPaperId = 999L;
+
+		// when
+		List<MessageResponse> result = messageService.getMessages(
+			nonExistentPaperId, MessageType.RECEIVE, request, toUser.getId()
+		);
+
+		// then
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("메시지 목록 조회 - 삭제된 메시지 제외")
+	void getMessages_ExcludeDeletedMessages() {
+		// given
+		savedMessage.updateDeleteStatus();
+		messageRepository.save(savedMessage);
+
+		CursorPageRequest request = new CursorPageRequest(null, 10);
+
+		// when
+		List<MessageResponse> result = messageService.getMessages(
+			paper.getId(), MessageType.RECEIVE, request, toUser.getId()
+		);
+
+		// then
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("메시지 작성 - 성공")
+	void createMessage_Success() {
+		// given
+		CreateMessageRequest request = new CreateMessageRequest(
+			paper.getId(), toUser.getId(), "새로운 메시지", "김철수", "Helvetica", "#00FF00"
+		);
+
+		// when
+		assertDoesNotThrow(() -> messageService.createMessage(request, fromUser.getId()));
+
+		// then
+		List<Message> messages = messageRepository.findAll();
+		Message createdMessage = messages.stream()
+			.filter(m -> m.getContent().equals("새로운 메시지"))
+			.findFirst()
+			.orElseThrow();
+
+		assertThat(createdMessage.getContent()).isEqualTo("새로운 메시지");
+		assertThat(createdMessage.getFontStyle()).isEqualTo("Helvetica");
+		assertThat(createdMessage.getBackgroundColor()).isEqualTo("#00FF00");
+		assertThat(createdMessage.getName()).isEqualTo("김철수");
+		assertThat(createdMessage.getFrom().getId()).isEqualTo(fromUser.getId());
+		assertThat(createdMessage.getTo().getId()).isEqualTo(toUser.getId());
+		assertThat(createdMessage.getPaper().getId()).isEqualTo(paper.getId());
+		assertThat(createdMessage.isDeleted()).isFalse();
+	}
+
+	@Test
+	@DisplayName("메시지 작성 - 발신자를 찾을 수 없음")
+	void createMessage_ThrowsException_FromUserNotFound() {
+		// given
+		Long nonExistentUserId = 999L;
+		CreateMessageRequest request = new CreateMessageRequest(
+			paper.getId(), toUser.getId(), "새로운 메시지", "Arial", "#FFFFFF", "김철수"
+		);
+
+		// when & then
+		CustomException exception = assertThrows(CustomException.class,
+			() -> messageService.createMessage(request, nonExistentUserId));
+
+		assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.USER_NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("메시지 작성 - 수신자를 찾을 수 없음")
+	void createMessage_ThrowsException_ToUserNotFound() {
+		// given
+		Long nonExistentUserId = 999L;
+		CreateMessageRequest request = new CreateMessageRequest(
+			paper.getId(), nonExistentUserId, "새로운 메시지", "Arial", "#FFFFFF", "김철수"
+		);
+
+		// when & then
+		CustomException exception = assertThrows(CustomException.class,
+			() -> messageService.createMessage(request, fromUser.getId()));
+
+		assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.USER_NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("메시지 작성 - 페이퍼를 찾을 수 없음")
+	void createMessage_ThrowsException_PaperNotFound() {
+		// given
+		Long nonExistentPaperId = 999L;
+		CreateMessageRequest request = new CreateMessageRequest(
+			nonExistentPaperId, toUser.getId(), "새로운 메시지", "Arial", "#FFFFFF", "김철수"
+		);
+
+		// when & then
+		CustomException exception = assertThrows(CustomException.class,
+			() -> messageService.createMessage(request, fromUser.getId()));
+
+		assertThat(exception.getErrorCode()).isEqualTo(PaperErrorCode.PAPER_NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("메시지 수정 - 성공")
+	void updateMessage_Success() {
+		// given
+		UpdateMessageRequest request = new UpdateMessageRequest(
+			savedMessage.getId(), "Georgia", "#FF0000", "수정된 내용", "수정된 이름"
+		);
+
+		// when
+		assertDoesNotThrow(() -> messageService.updateMessage(request, fromUser.getId()));
+
+		// then
+		Message updatedMessage = messageRepository.findById(savedMessage.getId()).orElseThrow();
+		assertThat(updatedMessage.getContent()).isEqualTo("수정된 내용");
+		assertThat(updatedMessage.getFontStyle()).isEqualTo("Georgia");
+		assertThat(updatedMessage.getBackgroundColor()).isEqualTo("#FF0000");
+		assertThat(updatedMessage.getName()).isEqualTo("수정된 이름");
+	}
+
+	@Test
+	@DisplayName("메시지 수정 - 메시지를 찾을 수 없음")
+	void updateMessage_ThrowsException_MessageNotFound() {
+		// given
+		Long nonExistentMessageId = 999L;
+		UpdateMessageRequest request = new UpdateMessageRequest(
+			nonExistentMessageId, "수정된 내용", "Georgia", "#FF0000", "수정된 이름"
+		);
+
+		// when & then
+		CustomException exception = assertThrows(CustomException.class,
+			() -> messageService.updateMessage(request, fromUser.getId()));
+
+		assertThat(exception.getErrorCode()).isEqualTo(MessageErrorCode.MESSAGE_NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("메시지 수정 - 다른 사용자의 메시지 접근 시도")
+	void updateMessage_ThrowsException_UnauthorizedAccess() {
+		// given
+		User otherUser = createAndSaveUser("other", "다른사용자", "other@test.com", "01011111111", "password789");
+
+		UpdateMessageRequest request = new UpdateMessageRequest(
+			savedMessage.getId(), "수정된 내용", "Georgia", "#FF0000", "수정된 이름"
+		);
+
+		// when & then
+		CustomException exception = assertThrows(CustomException.class,
+			() -> messageService.updateMessage(request, otherUser.getId()));
+
+		assertThat(exception.getErrorCode()).isEqualTo(MessageErrorCode.MESSAGE_NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("메시지 삭제 - 성공")
+	void deleteMessage_Success() {
+		// given
+		DeleteMessageRequest request = new DeleteMessageRequest(savedMessage.getId());
+
+		// when
+		assertDoesNotThrow(() -> messageService.deleteMessage(request, fromUser.getId()));
+
+		// then
+		Message deletedMessage = messageRepository.findById(savedMessage.getId()).orElseThrow();
+		assertThat(deletedMessage.isDeleted()).isTrue();
+	}
+
+	@Test
+	@DisplayName("메시지 삭제 - 메시지를 찾을 수 없음")
+	void deleteMessage_ThrowsException_MessageNotFound() {
+		// given
+		Long nonExistentMessageId = 999L;
+		DeleteMessageRequest request = new DeleteMessageRequest(nonExistentMessageId);
+
+		// when & then
+		CustomException exception = assertThrows(CustomException.class,
+			() -> messageService.deleteMessage(request, fromUser.getId()));
+
+		assertThat(exception.getErrorCode()).isEqualTo(MessageErrorCode.MESSAGE_NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("메시지 삭제 - 다른 사용자의 메시지 접근 시도")
+	void deleteMessage_ThrowsException_UnauthorizedAccess() {
+		// given
+		User otherUser = createAndSaveUser("other", "다른사용자", "other@test.com", "01011111111", "password789");
+
+		DeleteMessageRequest request = new DeleteMessageRequest(savedMessage.getId());
+
+		// when & then
+		CustomException exception = assertThrows(CustomException.class,
+			() -> messageService.deleteMessage(request, otherUser.getId()));
+
+		assertThat(exception.getErrorCode()).isEqualTo(MessageErrorCode.MESSAGE_NOT_FOUND);
+	}
+}


### PR DESCRIPTION
## 📄 PR 내용

- #60 
- 메시지 CRUD 기능을 추가했습니다. 기존에 만드셨던 MessageResponse DTO에 필드들을 추가했으며 CursorPageRequest에 @Min을 통해 size의 최솟값을 설정했습니다. 롤링페이퍼 조회와 다르게 메시지 조회는 최신순/오래된 순 그런게 아닌 최신순만 존재하므로 querydsl에서 그에 맞게 수정을 했습니다. 삭제했을 때는 삭제여부 상태만 업데이트를 했습니다. 이와 관련해서는 추후에 스케쥴링을 통해 삭제 할 수 있을것 같습니다.
원래 Controller, Service 단만 테스트를 하려고했는데 QueryDsl은 개발자가 직접 java문법으로 쿼리를 작성하기에 의도치 않게 동작을 할 가능성이있다고 판단이 들어 이부분만 테스트 코드를 작성했습니다. 
- AuthService는 Redis와 관련되어있어서 어쩔수 없이 mock 객체를 이용했지만 MessageService는 Redis를 사용하지 않았기에 통합테스트로 진행했습니다. 속도는 상대적으로 느리지만 비즈니스 흐름에따른 정확도는 더 높다고 판단이 들어 통합테스트로 진행했습니다.

## 📝 수정 상세 내용 

- 기존 Message Controller DTO 필드 변경
- QueryDSL 메서드 추가
- QueryDSL 테스트 코드 작성

## ✅ 체크리스트

- [X] 기존 Message Controller DTO 필드 변경
- [X] QueryDSL 메서드 추가
- [X] QueryDSL 테스트 코드 작성

## 📍 레퍼런스

- [통합테스트 vs 단위테스트](https://myeongju00.tistory.com/120)