### PR TITLE
[FEAT] 신고 관련 API 개발

### DIFF
--- a/src/main/java/doldol_server/doldol/common/exception/errorCode/ReportErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/errorCode/ReportErrorCode.java
@@ -1,0 +1,17 @@
+package doldol_server.doldol.common.exception.errorCode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReportErrorCode implements ErrorCode {
+	REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "P-001", "해당 신고 내역을 찾을 수 없습니다."),
+	REPORT_FORBIDDIN(HttpStatus.FORBIDDEN, "P-002", "해당 신고 내역에 접근할 권한이 없습니다.");
+
+	private HttpStatus httpStatus;
+	private String code;
+	private String message;
+}

--- a/src/main/java/doldol_server/doldol/common/exception/errorCode/ReportErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/errorCode/ReportErrorCode.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ReportErrorCode implements ErrorCode {
 	REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "P-001", "해당 신고 내역을 찾을 수 없습니다."),
-	REPORT_FORBIDDIN(HttpStatus.FORBIDDEN, "P-002", "해당 신고 내역에 접근할 권한이 없습니다.");
+	REPORT_FORBIDDEN(HttpStatus.FORBIDDEN, "P-002", "해당 신고 내역에 접근할 권한이 없습니다.");
 
 	private HttpStatus httpStatus;
 	private String code;

--- a/src/main/java/doldol_server/doldol/report/controller/ReportController.java
+++ b/src/main/java/doldol_server/doldol/report/controller/ReportController.java
@@ -49,7 +49,7 @@ public class ReportController {
 	public ApiResponse<ReportResponse> getComplaint(
 		@PathVariable("id") Long reportId,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
-		ReportResponse response = null;
+		ReportResponse response = reportService.getReportDetail(reportId, userDetails.getUserId());
 		return ApiResponse.ok(response);
 	}
 

--- a/src/main/java/doldol_server/doldol/report/controller/ReportController.java
+++ b/src/main/java/doldol_server/doldol/report/controller/ReportController.java
@@ -2,6 +2,7 @@ package doldol_server.doldol.report.controller;
 
 import java.util.List;
 
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import doldol_server.doldol.auth.dto.CustomUserDetails;
+import doldol_server.doldol.common.request.CursorPageRequest;
 import doldol_server.doldol.common.response.ApiResponse;
 import doldol_server.doldol.report.dto.request.ReportRequest;
 import doldol_server.doldol.report.dto.response.ReportResponse;
@@ -34,11 +36,12 @@ public class ReportController {
 		summary = "신고 내역 조회 API",
 		description = "신고 내역 조회",
 		security = {@SecurityRequirement(name = "jwt")})
-	public ApiResponse<List<ReportResponse>> getComplaints(
-		@AuthenticationPrincipal CustomUserDetails userDetails) {
-		Long userId = userDetails.getUserId();
-		List<ReportResponse> response = reportService.getUserReports(userId);
-		return ApiResponse.ok(response);
+	public ApiResponse<List<ReportResponse>> getReports(
+		@ParameterObject @Valid CursorPageRequest request,
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		List<ReportResponse> reports = reportService.getUserReports(request, userDetails.getUserId());
+		return ApiResponse.ok(reports);
 	}
 
 	@GetMapping("/{id}")

--- a/src/main/java/doldol_server/doldol/report/controller/ReportController.java
+++ b/src/main/java/doldol_server/doldol/report/controller/ReportController.java
@@ -14,15 +14,20 @@ import doldol_server.doldol.auth.dto.CustomUserDetails;
 import doldol_server.doldol.common.response.ApiResponse;
 import doldol_server.doldol.report.dto.request.ReportRequest;
 import doldol_server.doldol.report.dto.response.ReportResponse;
+import doldol_server.doldol.report.service.ReportService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @Tag(name = "신고")
 @RestController
 @RequestMapping("/reports")
+@RequiredArgsConstructor
 public class ReportController {
+
+	private final ReportService reportService;
 
 	@GetMapping
 	@Operation(
@@ -31,7 +36,8 @@ public class ReportController {
 		security = {@SecurityRequirement(name = "jwt")})
 	public ApiResponse<List<ReportResponse>> getComplaints(
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
-		List<ReportResponse> response = null;
+		Long userId = userDetails.getUserId();
+		List<ReportResponse> response = reportService.getUserReports(userId);
 		return ApiResponse.ok(response);
 	}
 

--- a/src/main/java/doldol_server/doldol/report/controller/ReportController.java
+++ b/src/main/java/doldol_server/doldol/report/controller/ReportController.java
@@ -2,6 +2,7 @@ package doldol_server.doldol.report.controller;
 
 import java.util.List;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,11 +35,11 @@ public class ReportController {
 		summary = "신고 내역 조회 API",
 		description = "신고 내역 조회",
 		security = {@SecurityRequirement(name = "jwt")})
-	public ApiResponse<List<ReportResponse>> getComplaints(
+	public ResponseEntity<ApiResponse<List<ReportResponse>>> getComplaints(
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		Long userId = userDetails.getUserId();
 		List<ReportResponse> response = reportService.getUserReports(userId);
-		return ApiResponse.ok(response);
+		return ResponseEntity.ok(ApiResponse.ok(response));
 	}
 
 	@GetMapping("/{id}")
@@ -46,11 +47,11 @@ public class ReportController {
 		summary = "신고 상세 조회 API",
 		description = "신고 상세 조회",
 		security = {@SecurityRequirement(name = "jwt")})
-	public ApiResponse<ReportResponse> getComplaint(
+	public ResponseEntity<ApiResponse<ReportResponse>> getComplaint(
 		@PathVariable("id") Long reportId,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		ReportResponse response = reportService.getReportDetail(reportId, userDetails.getUserId());
-		return ApiResponse.ok(response);
+		return ResponseEntity.ok(ApiResponse.ok(response));
 	}
 
 	@PostMapping
@@ -58,10 +59,10 @@ public class ReportController {
 		summary = "신고 작성 API",
 		description = "신고",
 		security = {@SecurityRequirement(name = "jwt")})
-	public ApiResponse<ReportResponse> createMessage(
+	public ResponseEntity<ApiResponse<ReportResponse>> createMessage(
 		@RequestBody @Valid ReportRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		ReportResponse response = reportService.createReport(request, userDetails.getUserId());
-		return ApiResponse.created(response);
+		return ResponseEntity.ok(ApiResponse.created(response));
 	}
 }

--- a/src/main/java/doldol_server/doldol/report/controller/ReportController.java
+++ b/src/main/java/doldol_server/doldol/report/controller/ReportController.java
@@ -61,7 +61,7 @@ public class ReportController {
 	public ApiResponse<ReportResponse> createMessage(
 		@RequestBody @Valid ReportRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
-		ReportResponse response = null;
+		ReportResponse response = reportService.createReport(request, userDetails.getUserId());
 		return ApiResponse.created(response);
 	}
 }

--- a/src/main/java/doldol_server/doldol/report/controller/ReportController.java
+++ b/src/main/java/doldol_server/doldol/report/controller/ReportController.java
@@ -2,7 +2,6 @@ package doldol_server.doldol.report.controller;
 
 import java.util.List;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -35,11 +34,11 @@ public class ReportController {
 		summary = "신고 내역 조회 API",
 		description = "신고 내역 조회",
 		security = {@SecurityRequirement(name = "jwt")})
-	public ResponseEntity<ApiResponse<List<ReportResponse>>> getComplaints(
+	public ApiResponse<List<ReportResponse>> getComplaints(
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		Long userId = userDetails.getUserId();
 		List<ReportResponse> response = reportService.getUserReports(userId);
-		return ResponseEntity.ok(ApiResponse.ok(response));
+		return ApiResponse.ok(response);
 	}
 
 	@GetMapping("/{id}")
@@ -47,11 +46,11 @@ public class ReportController {
 		summary = "신고 상세 조회 API",
 		description = "신고 상세 조회",
 		security = {@SecurityRequirement(name = "jwt")})
-	public ResponseEntity<ApiResponse<ReportResponse>> getComplaint(
+	public ApiResponse<ReportResponse> getComplaint(
 		@PathVariable("id") Long reportId,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		ReportResponse response = reportService.getReportDetail(reportId, userDetails.getUserId());
-		return ResponseEntity.ok(ApiResponse.ok(response));
+		return ApiResponse.ok(response);
 	}
 
 	@PostMapping
@@ -59,10 +58,10 @@ public class ReportController {
 		summary = "신고 작성 API",
 		description = "신고",
 		security = {@SecurityRequirement(name = "jwt")})
-	public ResponseEntity<ApiResponse<ReportResponse>> createMessage(
+	public ApiResponse<ReportResponse> createMessage(
 		@RequestBody @Valid ReportRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		ReportResponse response = reportService.createReport(request, userDetails.getUserId());
-		return ResponseEntity.ok(ApiResponse.created(response));
+		return ApiResponse.created(response);
 	}
 }

--- a/src/main/java/doldol_server/doldol/report/dto/request/ReportRequest.java
+++ b/src/main/java/doldol_server/doldol/report/dto/request/ReportRequest.java
@@ -20,8 +20,7 @@ public record ReportRequest(
 	@Schema(description = "내용", example = "김돌돌씨를 신고합니다.")
 	String content,
 
-	@NotBlank(message = "생성 날짜는 필수입니다.")
-	@NotNull
+	@NotNull(message = "생성 날짜는 필수입니다.")
 	@Schema(description = "생성 날짜", example = "2025-05-26T11:44:30.327959")
 	LocalDateTime createdAt
 ) {

--- a/src/main/java/doldol_server/doldol/report/dto/response/ReportResponse.java
+++ b/src/main/java/doldol_server/doldol/report/dto/response/ReportResponse.java
@@ -2,6 +2,7 @@ package doldol_server.doldol.report.dto.response;
 
 import java.time.LocalDateTime;
 
+import doldol_server.doldol.report.entity.Report;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "ReportResponse: 신고 내역 응답 Dto")
@@ -24,4 +25,14 @@ public record ReportResponse(
 	@Schema(description = "답변 여부", example = "false")
 	boolean isAnswered
 ) {
+	public static ReportResponse of(Report report) {
+		return new ReportResponse(
+			report.getMessage().getId(),
+			report.getMessage().getContent(),
+			report.getTitle(),
+			report.getContent(),
+			report.getCreatedAt(),
+			report.getAnswer() != null
+		);
+	}
 }

--- a/src/main/java/doldol_server/doldol/report/dto/response/ReportResponse.java
+++ b/src/main/java/doldol_server/doldol/report/dto/response/ReportResponse.java
@@ -9,6 +9,9 @@ public record ReportResponse(
 	@Schema(description = "메세지 ID", example = "1")
 	Long messageId,
 
+	@Schema(description = "메시지 내용", example = "넌 바보야")
+	String messageContent,
+
 	@Schema(description = "제목", example = "신고합니다.")
 	String title,
 

--- a/src/main/java/doldol_server/doldol/report/entity/Report.java
+++ b/src/main/java/doldol_server/doldol/report/entity/Report.java
@@ -35,10 +35,6 @@ public class Report extends BaseEntity {
 	private User user;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "admin_id")
-	private User admin;
-
-	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "message_id")
 	private Message message;
 

--- a/src/main/java/doldol_server/doldol/report/entity/Report.java
+++ b/src/main/java/doldol_server/doldol/report/entity/Report.java
@@ -1,6 +1,7 @@
 package doldol_server.doldol.report.entity;
 
 import doldol_server.doldol.common.entity.BaseEntity;
+import doldol_server.doldol.common.exception.errorCode.UserErrorCode;
 import doldol_server.doldol.rollingPaper.entity.Message;
 import doldol_server.doldol.rollingPaper.entity.Paper;
 import doldol_server.doldol.user.entity.User;
@@ -20,8 +21,6 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Report extends BaseEntity {
 
@@ -49,4 +48,14 @@ public class Report extends BaseEntity {
 
 	@Column(name = "is_solved", nullable = false)
 	private boolean isSolved;
+
+	@Builder
+	public Report(User user, Message message, String title, String content, String answer, boolean isSolved) {
+		this.user = user;
+		this.message = message;
+		this.title = title;
+		this.content = content;
+		this.answer = answer;
+		this.isSolved = isSolved;
+	}
 }

--- a/src/main/java/doldol_server/doldol/report/entity/Report.java
+++ b/src/main/java/doldol_server/doldol/report/entity/Report.java
@@ -38,6 +38,9 @@ public class Report extends BaseEntity {
 	@JoinColumn(name = "message_id")
 	private Message message;
 
+	@Column(name = "title", nullable = false)
+	private String title;
+
 	@Column(name = "content", nullable = false)
 	private String content;
 

--- a/src/main/java/doldol_server/doldol/report/entity/Report.java
+++ b/src/main/java/doldol_server/doldol/report/entity/Report.java
@@ -13,11 +13,15 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Report extends BaseEntity {
 

--- a/src/main/java/doldol_server/doldol/report/entity/Report.java
+++ b/src/main/java/doldol_server/doldol/report/entity/Report.java
@@ -30,10 +30,6 @@ public class Report extends BaseEntity {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id")
-	private User user;
-
-	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "message_id")
 	private Message message;
 
@@ -50,8 +46,7 @@ public class Report extends BaseEntity {
 	private boolean isSolved;
 
 	@Builder
-	public Report(User user, Message message, String title, String content, String answer, boolean isSolved) {
-		this.user = user;
+	public Report(Message message, String title, String content, String answer, boolean isSolved) {
 		this.message = message;
 		this.title = title;
 		this.content = content;

--- a/src/main/java/doldol_server/doldol/report/repository/ReportRepository.java
+++ b/src/main/java/doldol_server/doldol/report/repository/ReportRepository.java
@@ -1,11 +1,9 @@
 package doldol_server.doldol.report.repository;
 
-import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import doldol_server.doldol.report.entity.Report;
+import doldol_server.doldol.report.repository.custom.ReportRepositoryCustom;
 
-public interface ReportRepository extends JpaRepository<Report, Long> {
-	List<Report> findByUserId(Long userId);
+public interface ReportRepository extends JpaRepository<Report, Long>, ReportRepositoryCustom {
 }

--- a/src/main/java/doldol_server/doldol/report/repository/ReportRepository.java
+++ b/src/main/java/doldol_server/doldol/report/repository/ReportRepository.java
@@ -1,0 +1,11 @@
+package doldol_server.doldol.report.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import doldol_server.doldol.report.entity.Report;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+	List<Report> findByUserId(Long userId);
+}

--- a/src/main/java/doldol_server/doldol/report/repository/custom/ReportRepositoryCustom.java
+++ b/src/main/java/doldol_server/doldol/report/repository/custom/ReportRepositoryCustom.java
@@ -2,9 +2,9 @@ package doldol_server.doldol.report.repository.custom;
 
 import java.util.List;
 
-import doldol_server.doldol.report.entity.Report;
+import doldol_server.doldol.report.dto.response.ReportResponse;
 
 public interface ReportRepositoryCustom {
-	List<Report> findReportsByUserId(Long userId);
-	Report findByIdAndUserId(Long reportId, Long userId);
+	List<ReportResponse> findReportsByUserId(Long userId);
+	ReportResponse findByReportIdAndUserId(Long reportId, Long userId);
 }

--- a/src/main/java/doldol_server/doldol/report/repository/custom/ReportRepositoryCustom.java
+++ b/src/main/java/doldol_server/doldol/report/repository/custom/ReportRepositoryCustom.java
@@ -1,11 +1,10 @@
 package doldol_server.doldol.report.repository.custom;
 
 import java.util.List;
-import java.util.Optional;
 
 import doldol_server.doldol.report.entity.Report;
 
 public interface ReportRepositoryCustom {
 	List<Report> findReportsByUserId(Long userId);
-	Optional<Report> findByIdAndUserId(Long reportId, Long userId);
+	Report findByIdAndUserId(Long reportId, Long userId);
 }

--- a/src/main/java/doldol_server/doldol/report/repository/custom/ReportRepositoryCustom.java
+++ b/src/main/java/doldol_server/doldol/report/repository/custom/ReportRepositoryCustom.java
@@ -1,0 +1,11 @@
+package doldol_server.doldol.report.repository.custom;
+
+import java.util.List;
+import java.util.Optional;
+
+import doldol_server.doldol.report.entity.Report;
+
+public interface ReportRepositoryCustom {
+	List<Report> findReportsByUserId(Long userId);
+	Optional<Report> findByIdAndUserId(Long reportId, Long userId);
+}

--- a/src/main/java/doldol_server/doldol/report/repository/custom/ReportRepositoryCustom.java
+++ b/src/main/java/doldol_server/doldol/report/repository/custom/ReportRepositoryCustom.java
@@ -2,9 +2,10 @@ package doldol_server.doldol.report.repository.custom;
 
 import java.util.List;
 
+import doldol_server.doldol.common.request.CursorPageRequest;
 import doldol_server.doldol.report.dto.response.ReportResponse;
 
 public interface ReportRepositoryCustom {
-	List<ReportResponse> findReportsByUserId(Long userId);
+	List<ReportResponse> findReportsByUserId(Long userId, CursorPageRequest request);
 	ReportResponse findByReportIdAndUserId(Long reportId, Long userId);
 }

--- a/src/main/java/doldol_server/doldol/report/repository/custom/ReportRepositoryImpl.java
+++ b/src/main/java/doldol_server/doldol/report/repository/custom/ReportRepositoryImpl.java
@@ -1,0 +1,44 @@
+package doldol_server.doldol.report.repository.custom;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import doldol_server.doldol.report.entity.QReport;
+import doldol_server.doldol.report.entity.Report;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ReportRepositoryImpl implements ReportRepositoryCustom {
+	private final JPAQueryFactory queryFactory;
+
+	private final QReport report = QReport.report;
+
+	@Override
+	public List<Report> findReportsByUserId(Long userId) {
+		return queryFactory
+			.selectFrom(report)
+			.leftJoin(report.message).fetchJoin()
+			.where(report.user.id.eq(userId))
+			.orderBy(report.id.desc())
+			.fetch();
+	}
+
+	@Override
+	public Optional<Report> findByIdAndUserId(Long reportId, Long userId) {
+		return Optional.ofNullable(
+			queryFactory
+				.selectFrom(report)
+				.leftJoin(report.message).fetchJoin()
+				.where(
+					report.id.eq(reportId),
+					report.user.id.eq(userId)
+				)
+				.fetchOne()
+		);
+	}
+}

--- a/src/main/java/doldol_server/doldol/report/repository/custom/ReportRepositoryImpl.java
+++ b/src/main/java/doldol_server/doldol/report/repository/custom/ReportRepositoryImpl.java
@@ -2,39 +2,47 @@ package doldol_server.doldol.report.repository.custom;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
-
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import doldol_server.doldol.common.request.CursorPageRequest;
 import doldol_server.doldol.report.dto.response.ReportResponse;
 import doldol_server.doldol.report.entity.QReport;
+import doldol_server.doldol.report.entity.Report;
+import doldol_server.doldol.rollingPaper.entity.QMessage;
 import lombok.RequiredArgsConstructor;
 
-@Repository
 @RequiredArgsConstructor
 public class ReportRepositoryImpl implements ReportRepositoryCustom {
+
 	private final JPAQueryFactory queryFactory;
 
 	private final QReport report = QReport.report;
+	private final QMessage message = QMessage.message;
 
 	@Override
-	public List<ReportResponse> findReportsByUserId(Long userId) {
-		return queryFactory
-			.select(Projections.constructor(
-				ReportResponse.class,
-				report.message.id,
-				report.message.content,
-				report.title,
-				report.content,
-				report.createdAt,
-				report.answer.isNotNull()
-			))
-			.from(report)
-			.join(report.message)
-			.where(report.message.to.id.eq(userId))
+	public List<ReportResponse> findReportsByUserId(Long userId, CursorPageRequest request) {
+		QReport report = QReport.report;
+		QMessage message = QMessage.message;
+
+		BooleanExpression cursorCondition = null;
+		if (request.cursorId() != null) {
+			cursorCondition = report.id.lt(request.cursorId());
+		}
+
+		List<Report> reports = queryFactory
+			.selectFrom(report)
+			.join(report.message, message).fetchJoin()
+			.where(
+				message.to.id.eq(userId),
+				cursorCondition
+			)
 			.orderBy(report.id.desc())
+			.limit(request.size() + 1L)
 			.fetch();
+
+		return reports.stream().map(ReportResponse::of).toList();
 	}
 
 	@Override
@@ -50,11 +58,12 @@ public class ReportRepositoryImpl implements ReportRepositoryCustom {
 				report.answer.isNotNull()
 			))
 			.from(report)
-			.join(report.message)
+			.join(report.message, message)
 			.where(
 				report.id.eq(reportId),
-				report.message.to.id.eq(userId)
+				message.to.id.eq(userId)
 			)
 			.fetchOne();
 	}
 }
+

--- a/src/main/java/doldol_server/doldol/report/repository/custom/ReportRepositoryImpl.java
+++ b/src/main/java/doldol_server/doldol/report/repository/custom/ReportRepositoryImpl.java
@@ -29,16 +29,14 @@ public class ReportRepositoryImpl implements ReportRepositoryCustom {
 	}
 
 	@Override
-	public Optional<Report> findByIdAndUserId(Long reportId, Long userId) {
-		return Optional.ofNullable(
-			queryFactory
-				.selectFrom(report)
-				.leftJoin(report.message).fetchJoin()
-				.where(
-					report.id.eq(reportId),
-					report.user.id.eq(userId)
-				)
-				.fetchOne()
-		);
+	public Report findByIdAndUserId(Long reportId, Long userId) {
+		return queryFactory
+			.selectFrom(report)
+			.leftJoin(report.message).fetchJoin()
+			.where(
+				report.id.eq(reportId),
+				report.user.id.eq(userId)
+			)
+			.fetchOne();
 	}
 }

--- a/src/main/java/doldol_server/doldol/report/repository/custom/ReportRepositoryImpl.java
+++ b/src/main/java/doldol_server/doldol/report/repository/custom/ReportRepositoryImpl.java
@@ -32,7 +32,7 @@ public class ReportRepositoryImpl implements ReportRepositoryCustom {
 			))
 			.from(report)
 			.join(report.message)
-			.where(report.user.id.eq(userId))
+			.where(report.message.to.id.eq(userId))
 			.orderBy(report.id.desc())
 			.fetch();
 	}
@@ -53,7 +53,7 @@ public class ReportRepositoryImpl implements ReportRepositoryCustom {
 			.join(report.message)
 			.where(
 				report.id.eq(reportId),
-				report.user.id.eq(userId)
+				report.message.to.id.eq(userId)
 			)
 			.fetchOne();
 	}

--- a/src/main/java/doldol_server/doldol/report/repository/custom/ReportRepositoryImpl.java
+++ b/src/main/java/doldol_server/doldol/report/repository/custom/ReportRepositoryImpl.java
@@ -1,14 +1,14 @@
 package doldol_server.doldol.report.repository.custom;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import doldol_server.doldol.report.dto.response.ReportResponse;
 import doldol_server.doldol.report.entity.QReport;
-import doldol_server.doldol.report.entity.Report;
 import lombok.RequiredArgsConstructor;
 
 @Repository
@@ -19,20 +19,38 @@ public class ReportRepositoryImpl implements ReportRepositoryCustom {
 	private final QReport report = QReport.report;
 
 	@Override
-	public List<Report> findReportsByUserId(Long userId) {
+	public List<ReportResponse> findReportsByUserId(Long userId) {
 		return queryFactory
-			.selectFrom(report)
-			.leftJoin(report.message).fetchJoin()
+			.select(Projections.constructor(
+				ReportResponse.class,
+				report.message.id,
+				report.message.content,
+				report.title,
+				report.content,
+				report.createdAt,
+				report.answer.isNotNull()
+			))
+			.from(report)
+			.join(report.message)
 			.where(report.user.id.eq(userId))
 			.orderBy(report.id.desc())
 			.fetch();
 	}
 
 	@Override
-	public Report findByIdAndUserId(Long reportId, Long userId) {
+	public ReportResponse findByReportIdAndUserId(Long reportId, Long userId) {
 		return queryFactory
-			.selectFrom(report)
-			.leftJoin(report.message).fetchJoin()
+			.select(Projections.constructor(
+				ReportResponse.class,
+				report.message.id,
+				report.message.content,
+				report.title,
+				report.content,
+				report.createdAt,
+				report.answer.isNotNull()
+			))
+			.from(report)
+			.join(report.message)
 			.where(
 				report.id.eq(reportId),
 				report.user.id.eq(userId)

--- a/src/main/java/doldol_server/doldol/report/service/ReportService.java
+++ b/src/main/java/doldol_server/doldol/report/service/ReportService.java
@@ -1,7 +1,6 @@
 package doldol_server.doldol.report.service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,7 +29,7 @@ public class ReportService {
 	private final MessageRepository messageRepository;
 
 	public List<ReportResponse> getUserReports(Long userId) {
-		List<Report> reports = reportRepository.findByUserId(userId);
+		List<Report> reports = reportRepository.findReportsByUserId(userId);
 
 		return reports.stream()
 			.map(report -> new ReportResponse(
@@ -39,16 +38,13 @@ public class ReportService {
 				report.getContent(),
 				report.getCreatedAt(),
 				report.getAnswer() != null
-			)).collect(Collectors.toList());
+			)).toList();
 	}
 
 	public ReportResponse getReportDetail(Long reportId, Long userId) {
-		Report report = reportRepository.findById(reportId)
+		Report report = reportRepository.findByIdAndUserId(reportId, userId)
 			.orElseThrow(() -> new CustomException(ReportErrorCode.REPORT_NOT_FOUND));
 
-		if (!report.getUser().getId().equals(userId)) {
-			throw new CustomException(ReportErrorCode.REPORT_FORBIDDIN);
-		}
 		return new ReportResponse(
 			report.getMessage().getId(),
 			report.getTitle(),

--- a/src/main/java/doldol_server/doldol/report/service/ReportService.java
+++ b/src/main/java/doldol_server/doldol/report/service/ReportService.java
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 import doldol_server.doldol.common.exception.CustomException;
 import doldol_server.doldol.common.exception.errorCode.MessageErrorCode;
 import doldol_server.doldol.common.exception.errorCode.ReportErrorCode;
-import doldol_server.doldol.common.exception.errorCode.UserErrorCode;
 import doldol_server.doldol.report.dto.request.ReportRequest;
 import doldol_server.doldol.report.dto.response.ReportResponse;
 import doldol_server.doldol.report.entity.Report;
@@ -16,7 +15,7 @@ import doldol_server.doldol.report.repository.ReportRepository;
 import doldol_server.doldol.rollingPaper.entity.Message;
 import doldol_server.doldol.rollingPaper.repository.MessageRepository;
 import doldol_server.doldol.user.entity.User;
-import doldol_server.doldol.user.repository.UserRepository;
+import doldol_server.doldol.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -25,8 +24,8 @@ import lombok.RequiredArgsConstructor;
 public class ReportService {
 
 	private final ReportRepository reportRepository;
-	private final UserRepository userRepository;
 	private final MessageRepository messageRepository;
+	private final UserService userService;
 
 	public List<ReportResponse> getUserReports(Long userId) {
 		return reportRepository.findReportsByUserId(userId);
@@ -44,8 +43,7 @@ public class ReportService {
 
 	@Transactional
 	public ReportResponse createReport(ReportRequest request, Long userId) {
-		User reporter = userRepository.findById(userId)
-			.orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+		User reporter = userService.getById(userId);
 		Message message = messageRepository.findById(request.messageId())
 			.orElseThrow(() -> new CustomException(MessageErrorCode.MESSAGE_NOT_FOUND));
 
@@ -59,13 +57,6 @@ public class ReportService {
 
 		Report saved = reportRepository.save(report);
 
-		return new ReportResponse(
-			saved.getMessage().getId(),
-			saved.getMessage().getContent(),
-			saved.getTitle(),
-			saved.getContent(),
-			saved.getCreatedAt(),
-			false
-		);
+		return ReportResponse.of(saved);
 	}
 }

--- a/src/main/java/doldol_server/doldol/report/service/ReportService.java
+++ b/src/main/java/doldol_server/doldol/report/service/ReportService.java
@@ -58,6 +58,7 @@ public class ReportService {
 		);
 	}
 
+	@Transactional
 	public ReportResponse createReport(ReportRequest request, Long userId) {
 		User reporter = userRepository.findById(userId)
 			.orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));

--- a/src/main/java/doldol_server/doldol/report/service/ReportService.java
+++ b/src/main/java/doldol_server/doldol/report/service/ReportService.java
@@ -45,6 +45,10 @@ public class ReportService {
 		Message message = messageRepository.findById(request.messageId())
 			.orElseThrow(() -> new CustomException(MessageErrorCode.MESSAGE_NOT_FOUND));
 
+		if (!message.getTo().getId().equals(userId)) {
+			throw new CustomException(ReportErrorCode.REPORT_FORBIDDEN);
+		}
+
 		Report report = Report.builder()
 			.message(message)
 			.title(request.title())

--- a/src/main/java/doldol_server/doldol/report/service/ReportService.java
+++ b/src/main/java/doldol_server/doldol/report/service/ReportService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import doldol_server.doldol.common.exception.CustomException;
 import doldol_server.doldol.common.exception.errorCode.MessageErrorCode;
 import doldol_server.doldol.common.exception.errorCode.ReportErrorCode;
+import doldol_server.doldol.common.request.CursorPageRequest;
 import doldol_server.doldol.report.dto.request.ReportRequest;
 import doldol_server.doldol.report.dto.response.ReportResponse;
 import doldol_server.doldol.report.entity.Report;
@@ -26,8 +27,8 @@ public class ReportService {
 	private final MessageRepository messageRepository;
 	private final UserService userService;
 
-	public List<ReportResponse> getUserReports(Long userId) {
-		return reportRepository.findReportsByUserId(userId);
+	public List<ReportResponse> getUserReports(CursorPageRequest request, Long userId) {
+		return reportRepository.findReportsByUserId(userId, request);
 	}
 
 	public ReportResponse getReportDetail(Long reportId, Long userId) {

--- a/src/main/java/doldol_server/doldol/report/service/ReportService.java
+++ b/src/main/java/doldol_server/doldol/report/service/ReportService.java
@@ -5,6 +5,8 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import doldol_server.doldol.common.exception.CustomException;
+import doldol_server.doldol.common.exception.errorCode.ReportErrorCode;
 import doldol_server.doldol.report.dto.response.ReportResponse;
 import doldol_server.doldol.report.entity.Report;
 import doldol_server.doldol.report.repository.ReportRepository;
@@ -27,5 +29,21 @@ public class ReportService {
 				report.getCreatedAt(),
 				report.getAnswer() != null
 			)).collect(Collectors.toList());
+	}
+
+	public ReportResponse getReportDetail(Long reportId, Long userId) {
+		Report report = reportRepository.findById(reportId)
+			.orElseThrow(() -> new CustomException(ReportErrorCode.REPORT_NOT_FOUND));
+
+		if (!report.getUser().getId().equals(userId)) {
+			throw new CustomException(ReportErrorCode.REPORT_FORBIDDIN);
+		}
+		return new ReportResponse(
+			report.getMessage().getId(),
+			report.getTitle(),
+			report.getContent(),
+			report.getCreatedAt(),
+			report.getAnswer() != null
+		);
 	}
 }

--- a/src/main/java/doldol_server/doldol/report/service/ReportService.java
+++ b/src/main/java/doldol_server/doldol/report/service/ReportService.java
@@ -1,0 +1,31 @@
+package doldol_server.doldol.report.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import doldol_server.doldol.report.dto.response.ReportResponse;
+import doldol_server.doldol.report.entity.Report;
+import doldol_server.doldol.report.repository.ReportRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+	private final ReportRepository reportRepository;
+
+	public List<ReportResponse> getUserReports(Long userId) {
+		List<Report> reports = reportRepository.findByUserId(userId);
+
+		return reports.stream()
+			.map(report -> new ReportResponse(
+				report.getMessage().getId(),
+				report.getTitle(),
+				report.getContent(),
+				report.getCreatedAt(),
+				report.getAnswer() != null
+			)).collect(Collectors.toList());
+	}
+}

--- a/src/main/java/doldol_server/doldol/report/service/ReportService.java
+++ b/src/main/java/doldol_server/doldol/report/service/ReportService.java
@@ -29,29 +29,17 @@ public class ReportService {
 	private final MessageRepository messageRepository;
 
 	public List<ReportResponse> getUserReports(Long userId) {
-		List<Report> reports = reportRepository.findReportsByUserId(userId);
-
-		return reports.stream()
-			.map(report -> new ReportResponse(
-				report.getMessage().getId(),
-				report.getTitle(),
-				report.getContent(),
-				report.getCreatedAt(),
-				report.getAnswer() != null
-			)).toList();
+		return reportRepository.findReportsByUserId(userId);
 	}
 
 	public ReportResponse getReportDetail(Long reportId, Long userId) {
-		Report report = reportRepository.findByIdAndUserId(reportId, userId)
-			.orElseThrow(() -> new CustomException(ReportErrorCode.REPORT_NOT_FOUND));
+		ReportResponse response = reportRepository.findByReportIdAndUserId(reportId, userId);
 
-		return new ReportResponse(
-			report.getMessage().getId(),
-			report.getTitle(),
-			report.getContent(),
-			report.getCreatedAt(),
-			report.getAnswer() != null
-		);
+		if (response == null) {
+			throw new CustomException(ReportErrorCode.REPORT_NOT_FOUND);
+		}
+
+		return response;
 	}
 
 	@Transactional
@@ -73,6 +61,7 @@ public class ReportService {
 
 		return new ReportResponse(
 			saved.getMessage().getId(),
+			saved.getMessage().getContent(),
 			saved.getTitle(),
 			saved.getContent(),
 			saved.getCreatedAt(),

--- a/src/main/java/doldol_server/doldol/report/service/ReportService.java
+++ b/src/main/java/doldol_server/doldol/report/service/ReportService.java
@@ -14,7 +14,6 @@ import doldol_server.doldol.report.entity.Report;
 import doldol_server.doldol.report.repository.ReportRepository;
 import doldol_server.doldol.rollingPaper.entity.Message;
 import doldol_server.doldol.rollingPaper.repository.MessageRepository;
-import doldol_server.doldol.user.entity.User;
 import doldol_server.doldol.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 
@@ -43,12 +42,10 @@ public class ReportService {
 
 	@Transactional
 	public ReportResponse createReport(ReportRequest request, Long userId) {
-		User reporter = userService.getById(userId);
 		Message message = messageRepository.findById(request.messageId())
 			.orElseThrow(() -> new CustomException(MessageErrorCode.MESSAGE_NOT_FOUND));
 
 		Report report = Report.builder()
-			.user(reporter)
 			.message(message)
 			.title(request.title())
 			.content(request.content())

--- a/src/main/java/doldol_server/doldol/report/service/ReportService.java
+++ b/src/main/java/doldol_server/doldol/report/service/ReportService.java
@@ -4,19 +4,30 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import doldol_server.doldol.common.exception.CustomException;
+import doldol_server.doldol.common.exception.errorCode.MessageErrorCode;
 import doldol_server.doldol.common.exception.errorCode.ReportErrorCode;
+import doldol_server.doldol.common.exception.errorCode.UserErrorCode;
+import doldol_server.doldol.report.dto.request.ReportRequest;
 import doldol_server.doldol.report.dto.response.ReportResponse;
 import doldol_server.doldol.report.entity.Report;
 import doldol_server.doldol.report.repository.ReportRepository;
+import doldol_server.doldol.rollingPaper.entity.Message;
+import doldol_server.doldol.rollingPaper.repository.MessageRepository;
+import doldol_server.doldol.user.entity.User;
+import doldol_server.doldol.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ReportService {
 
 	private final ReportRepository reportRepository;
+	private final UserRepository userRepository;
+	private final MessageRepository messageRepository;
 
 	public List<ReportResponse> getUserReports(Long userId) {
 		List<Report> reports = reportRepository.findByUserId(userId);
@@ -44,6 +55,31 @@ public class ReportService {
 			report.getContent(),
 			report.getCreatedAt(),
 			report.getAnswer() != null
+		);
+	}
+
+	public ReportResponse createReport(ReportRequest request, Long userId) {
+		User reporter = userRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+		Message message = messageRepository.findById(request.messageId())
+			.orElseThrow(() -> new CustomException(MessageErrorCode.MESSAGE_NOT_FOUND));
+
+		Report report = Report.builder()
+			.user(reporter)
+			.message(message)
+			.title(request.title())
+			.content(request.content())
+			.isSolved(false)
+			.build();
+
+		Report saved = reportRepository.save(report);
+
+		return new ReportResponse(
+			saved.getMessage().getId(),
+			saved.getTitle(),
+			saved.getContent(),
+			saved.getCreatedAt(),
+			false
 		);
 	}
 }

--- a/src/test/java/doldol_server/doldol/report/service/ReportServiceTest.java
+++ b/src/test/java/doldol_server/doldol/report/service/ReportServiceTest.java
@@ -14,7 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import doldol_server.doldol.common.ServiceTest;
 import doldol_server.doldol.common.exception.CustomException;
 import doldol_server.doldol.common.exception.errorCode.MessageErrorCode;
-import doldol_server.doldol.common.exception.errorCode.UserErrorCode;
 import doldol_server.doldol.report.dto.request.ReportRequest;
 import doldol_server.doldol.report.dto.response.ReportResponse;
 import doldol_server.doldol.report.entity.Report;

--- a/src/test/java/doldol_server/doldol/report/service/ReportServiceTest.java
+++ b/src/test/java/doldol_server/doldol/report/service/ReportServiceTest.java
@@ -1,0 +1,117 @@
+package doldol_server.doldol.report.service;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import doldol_server.doldol.common.ServiceTest;
+import doldol_server.doldol.report.dto.response.ReportResponse;
+import doldol_server.doldol.report.entity.Report;
+import doldol_server.doldol.report.repository.ReportRepository;
+import doldol_server.doldol.rollingPaper.entity.Message;
+import doldol_server.doldol.rollingPaper.repository.MessageRepository;
+import doldol_server.doldol.user.entity.User;
+import doldol_server.doldol.user.repository.UserRepository;
+
+@DisplayName("Report 서비스 통합 테스트")
+class ReportServiceTest extends ServiceTest {
+
+	@Autowired
+	private ReportService reportService;
+
+	@Autowired
+	private ReportRepository reportRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private MessageRepository messageRepository;
+
+	private User reporter;
+	private User admin;
+	private Message message;
+
+	private Report savedReport;
+
+	@BeforeEach
+	void setUp() {
+		// 사용자 생성
+		reporter = userRepository.save(User.builder()
+			.loginId("reporter")
+			.name("홍길동")
+			.email("reporter@test.com")
+			.phone("01011112222")
+			.password("1234")
+			.build());
+
+		admin = userRepository.save(User.builder()
+			.loginId("admin")
+			.name("관리자")
+			.email("admin@test.com")
+			.phone("01099998888")
+			.password("admin123")
+			.build());
+
+		// 메시지 생성
+		message = messageRepository.save(Message.builder()
+			.name("김말자")
+			.content("욕설 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(reporter)
+			.to(admin)
+			.paper(null)
+			.build());
+
+		// 신고 생성
+		savedReport = reportRepository.save(Report.builder()
+			.user(reporter)
+			.admin(admin)
+			.message(message)
+			.title("신고합니다")
+			.content("부적절한 메시지를 신고합니다.")
+			.answer(null)
+			.isSolved(false)
+			.build());
+	}
+
+	@Test
+	@DisplayName("사용자 신고 내역 조회 - 성공")
+	void getUserReports_Success() {
+		// when
+		List<ReportResponse> result = reportService.getUserReports(reporter.getId());
+
+		// then
+		assertThat(result).hasSize(1);
+		ReportResponse response = result.get(0);
+		assertThat(response.title()).isEqualTo("신고합니다");
+		assertThat(response.content()).isEqualTo("부적절한 메시지를 신고합니다.");
+		assertThat(response.isAnswered()).isFalse();
+		assertThat(response.messageId()).isEqualTo(message.getId());
+	}
+
+	@Test
+	@DisplayName("사용자 신고 내역 조회 - 신고가 없는 경우")
+	void getUserReports_EmptyList() {
+		// given
+		User newUser = userRepository.save(User.builder()
+			.loginId("newuser")
+			.name("신규 사용자")
+			.email("newuser@test.com")
+			.phone("01012341234")
+			.password("newpass")
+			.build());
+
+		// when
+		List<ReportResponse> result = reportService.getUserReports(newUser.getId());
+
+		// then
+		assertThat(result).isEmpty();
+	}
+}

--- a/src/test/java/doldol_server/doldol/report/service/ReportServiceTest.java
+++ b/src/test/java/doldol_server/doldol/report/service/ReportServiceTest.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import doldol_server.doldol.common.ServiceTest;
 import doldol_server.doldol.common.exception.CustomException;
 import doldol_server.doldol.common.exception.errorCode.MessageErrorCode;
+import doldol_server.doldol.common.request.CursorPageRequest;
 import doldol_server.doldol.report.dto.request.ReportRequest;
 import doldol_server.doldol.report.dto.response.ReportResponse;
 import doldol_server.doldol.report.entity.Report;
@@ -84,8 +85,11 @@ class ReportServiceTest extends ServiceTest {
 	@Test
 	@DisplayName("사용자 신고 내역 조회 - 성공")
 	void getUserReports_Success() {
+		// given
+		CursorPageRequest request = new CursorPageRequest(null, 10);
+
 		// when
-		List<ReportResponse> result = reportService.getUserReports(receiver.getId());
+		List<ReportResponse> result = reportService.getUserReports(request, receiver.getId());
 
 		// then
 		assertThat(result).hasSize(1);
@@ -108,8 +112,10 @@ class ReportServiceTest extends ServiceTest {
 			.password("newpass")
 			.build());
 
+		CursorPageRequest request = new CursorPageRequest(null, 10);
+
 		// when
-		List<ReportResponse> result = reportService.getUserReports(newUser.getId());
+		List<ReportResponse> result = reportService.getUserReports(request, newUser.getId());
 
 		// then
 		assertThat(result).isEmpty();


### PR DESCRIPTION
## 📄 PR 내용

<!--- 작업에 대한 요약 설명을 작성해 주세요. -->

- 신고 기능 API를 구현했습니다.

## 📝 수정 상세 내용 

<!--- 작업 전과 후의 변화를 설명해 주세요. -->

###  ⚒️ 신고 기능 API 구현
다음과 같은 기능을 수행하는 메서드를 작성했습니다.
- 신고 전체 조회
- 신고 상세 조회
- 신고 생성

### ⚒️ 신고 관련 예외 처리 코드 추가
다음과 같은 예외 처리 코드를 추가했습니다.
- 해당 신고 내역을 찾을 수 없는 경우
- 해당 신고 내역에 접근할 권한이 없는 경우

### ⚒️ 테스트 코드 작성
다음과 같은 경우를 테스트하는 코드를 추가했습니다.
- 사용자 신고 내역 조회 -> 성공
- 사용자 신고 내역 조회 -> 신고가 없는 경우
- 신고 상세 조회 -> 성공
- 신고 상세 조회 -> 존재하지 않는 신고인 경우
- 신고 상세 조회 -> 다른 사용자의 신고 접근
- 신고 생성 -> 성공
- 신고 생성 -> 유저를 찾을 수 없음
- 신고 생성 -> 메시지를 찾을 수 없음

### ⚒️ 추가 수정 사항
- `Report` 엔티티에 `title` 필드 추가
신고 제목을 담은 `title` 필드를 추가했습니다.

- `Report` 엔티티에 `@Builder` 추가
테스트 코드 실행 시 임시 객체 생성이 필요하여 추가했습니다.

- `Report` 엔티티의 `admin` 필드 삭제
기획을 고려하였을 때, 관리자의 정보가 불필요하다고 판단하여 삭제하였습니다.

- `ReportRequest Dto` -> `createdAt` 필드의 `@NotBlank` 삭제
`@NotBlank`는 String 타입에서만 사용 가능한 제약 조건입니다. `LocalDateTime` 타입에서는 사용 불가능하기 때문에 제거 후 `@NotNull`로 대체하였습니다.



## ✅ 체크리스트

- [x] 신고 기능 API 구현
- [x] 신고 기능 테스트 코드 작성
- [x] 신고 기능 예외 처리 코드 작성

## 📍 레퍼런스
- @ehddbs4521 님과 @cherryiJuice 님의 코드를 참고하였습니다.