### PR TITLE
[REFACTOR] 공개 날짜를 기준으로 메시지 내용 여부 판단

### DIFF
--- a/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
@@ -1,6 +1,6 @@
 package doldol_server.doldol.rollingPaper.controller;
 
-import java.util.List;
+import java.time.LocalDateTime;
 
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +20,7 @@ import doldol_server.doldol.common.response.ApiResponse;
 import doldol_server.doldol.rollingPaper.dto.request.CreateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.request.DeleteMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.request.UpdateMessageRequest;
-import doldol_server.doldol.rollingPaper.dto.response.MessageResponse;
+import doldol_server.doldol.rollingPaper.dto.response.MessageListResponse;
 import doldol_server.doldol.rollingPaper.entity.MessageType;
 import doldol_server.doldol.rollingPaper.service.MessageService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -43,13 +43,15 @@ public class MessageController {
 		summary = "메세지 리스트 조회 API",
 		description = "메세지 리스트 조회",
 		security = {@SecurityRequirement(name = "jwt")})
-	public ResponseEntity<ApiResponse<List<MessageResponse>>> getMessages(
+	public ResponseEntity<ApiResponse<MessageListResponse>> getMessages(
 		@RequestParam("paperId") Long paperId,
 		@Parameter(description = "메시지 타입: RECEIVE(송신) 또는 SEND(발신)")
 		@RequestParam(defaultValue = "SEND") MessageType messageType,
+		@Parameter(description = "공개 날짜: 2025-05-26T11:44:30.327959")
+		@RequestParam LocalDateTime openDate,
 		@ParameterObject @Valid CursorPageRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
-		List<MessageResponse> messages = messageService.getMessages(paperId, messageType, request,
+		MessageListResponse messages = messageService.getMessages(paperId, messageType, openDate, request,
 			userDetails.getUserId());
 		return ResponseEntity.ok(ApiResponse.ok(messages));
 	}

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/response/MessageListResponse.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/response/MessageListResponse.java
@@ -1,20 +1,16 @@
 package doldol_server.doldol.rollingPaper.dto.response;
 
-import java.util.List;
-
+import doldol_server.doldol.common.dto.CursorPage;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "MessageListResponse: 메세지 리스트 응답 Dto")
 public record MessageListResponse(
-	@Schema(description = "메세지 갯수", example = "24")
+	@Schema(description = "총 메세지 수", example = "24")
 	int messageCount,
 
-	@Schema(description = "롤링페이퍼 url", example = "https://www.doldol.com/{uuid}")
-	String url,
-
-	@Schema(description = "관리자 여부", example = "true")
-	boolean isMaster,
-
-	List<MessageResponse> message
+	CursorPage<MessageResponse> message
 ) {
+	public static MessageListResponse of(int messageCount, CursorPage<MessageResponse> message) {
+		return new MessageListResponse(messageCount, message);
+	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/response/MessageResponse.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/response/MessageResponse.java
@@ -59,4 +59,18 @@ public record MessageResponse(
 			.updatedAt(message.getUpdatedAt())
 			.build();
 	}
+
+	public MessageResponse withNullContent() {
+		return MessageResponse.builder()
+			.messageId(this.messageId)
+			.messageType(this.messageType)
+			.content(null)
+			.fontStyle(this.fontStyle)
+			.backgroundColor(this.backgroundColor)
+			.isDeleted(this.isDeleted)
+			.name(this.name)
+			.createdAt(this.createdAt)
+			.updatedAt(this.updatedAt)
+			.build();
+	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/entity/Paper.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/entity/Paper.java
@@ -54,4 +54,12 @@ public class Paper extends BaseEntity {
 	public void addParticipant() {
 		participantsCount++;
 	}
+
+	public void addMessage() {
+		messageCount++;
+	}
+
+	public void deleteMessage() {
+		messageCount--;
+	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustom.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustom.java
@@ -21,4 +21,14 @@ public interface MessageRepositoryCustom {
 		Long userId,
 		CursorPageRequest request
 	);
+
+	Long getReceivedMessagesCount(
+		Long paperId,
+		Long userId
+	);
+
+	Long getSentdMessagesCount(
+		Long paperId,
+		Long userId
+	);
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustomImpl.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustomImpl.java
@@ -86,4 +86,34 @@ public class MessageRepositoryCustomImpl implements MessageRepositoryCustom {
 			.map(msg -> MessageResponse.of(msg, MessageType.SEND))
 			.toList();
 	}
+
+	@Override
+	public Long getReceivedMessagesCount(Long paperId, Long userId) {
+		QMessage message = QMessage.message;
+
+		return queryFactory
+			.select(message.count())
+			.from(message)
+			.where(
+				message.paper.id.eq(paperId),
+				message.to.id.eq(userId),
+				message.isDeleted.eq(false)
+			)
+			.fetchOne();
+	}
+
+	@Override
+	public Long getSentdMessagesCount(Long paperId, Long userId) {
+		QMessage message = QMessage.message;
+
+		return queryFactory
+			.select(message.count())
+			.from(message)
+			.where(
+				message.paper.id.eq(paperId),
+				message.from.id.eq(userId),
+				message.isDeleted.eq(false)
+			)
+			.fetchOne();
+	}
 }


### PR DESCRIPTION
## 📄 PR 내용

- #69 
- 날짜 여부를 이용한 메시지 데이터 응답값을 리팩토링했습니다. 추가로 메시지 작성 및 삭제 했을 때의 롤링페이퍼 총 데이터 갯수를 수정했습니다.

## 📝 수정 상세 내용 

- 날짜 여부를 이용한 메시지 데이터 응답값을 리팩토링
- 메시지 작성 및 삭제 했을 때의 롤링페이퍼 총 데이터 갯수 수정

## ✅ 체크리스트

- [X] 날짜 여부를 이용한 메시지 데이터 응답값을 리팩토링
- [X] 메시지 작성 및 삭제 했을 때의 롤링페이퍼 총 데이터 갯수 수정

## 📍 레퍼런스

- X