### PR TITLE
[REFACTOR] 메시지 수정 시 Null 처리 및 컨트롤러 응답값 포매팅

### DIFF
--- a/src/main/java/doldol_server/doldol/auth/controller/AuthController.java
+++ b/src/main/java/doldol_server/doldol/auth/controller/AuthController.java
@@ -1,6 +1,5 @@
 package doldol_server.doldol.auth.controller;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -44,69 +43,69 @@ public class AuthController {
 	@Operation(
 		summary = "이메일 중복 확인 API",
 		description = "이메일 중복 확인")
-	public ResponseEntity<ApiResponse<Void>> checkEmailDuplicate(
+	public ApiResponse<Void> checkEmailDuplicate(
 		@RequestBody @Valid EmailCheckRequest emailCheckRequest) {
 		authService.checkEmailDuplicate(emailCheckRequest.email());
-		return ResponseEntity.ok(ApiResponse.noContent());
+		return ApiResponse.noContent();
 	}
 
 	@PostMapping("/check-phone")
 	@Operation(
 		summary = "이메일 중복 확인 API",
 		description = "이메일 중복 확인")
-	public ResponseEntity<ApiResponse<Void>> checkphoneDuplicate(
+	public ApiResponse<Void> checkphoneDuplicate(
 		@RequestBody @Valid PhoneCheckRequest phoneCheckRequest) {
 		authService.checkPhoneDuplicate(phoneCheckRequest.phone());
-		return ResponseEntity.ok(ApiResponse.noContent());
+		return ApiResponse.noContent();
 	}
 
 	@PostMapping("/email/send-code")
 	@Operation(
 		summary = "이메일 인증 코드 전송 API",
 		description = "이메일 인증 코드 전송")
-	public ResponseEntity<ApiResponse<Void>> sendVerificationCode(
+	public ApiResponse<Void> sendVerificationCode(
 		@RequestBody @Valid EmailCodeSendRequest emailCodeSendRequest) {
 		authService.sendVerificationCode(emailCodeSendRequest.email());
-		return ResponseEntity.ok(ApiResponse.noContent());
+		return ApiResponse.noContent();
 	}
 
 	@PostMapping("/email/verify-code")
 	@Operation(
 		summary = "이메일 인증 코드 검증 API",
 		description = "이메일 인증 코드 검증")
-	public ResponseEntity<ApiResponse<Void>> validateVerificationCode(
+	public ApiResponse<Void> validateVerificationCode(
 		@RequestBody @Valid EmailCodeVerifyRequest emailCodeVerifyRequest) {
 		authService.validateVerificationCode(emailCodeVerifyRequest.email(), emailCodeVerifyRequest.code());
-		return ResponseEntity.ok(ApiResponse.noContent());
+		return ApiResponse.noContent();
 	}
 
 	@PostMapping("/register")
 	@Operation(
 		summary = "자체 서비스 회원가입 API",
 		description = "자체 서비 회원가입")
-	public ResponseEntity<ApiResponse<Void>> register(@RequestBody @Valid RegisterRequest registerRequest) {
+	public ApiResponse<Void> register(@RequestBody @Valid RegisterRequest registerRequest) {
 		authService.register(registerRequest);
-		return ResponseEntity.ok(ApiResponse.noContent());
+		return ApiResponse.noContent();
 	}
 
 	@PostMapping("/oauth/register")
 	@Operation(
 		summary = "소셜 회원가입 완료 API",
 		description = "소셜 회원가입 완료")
-	public ResponseEntity<ApiResponse<Void>> oauthRegister(
+	public ApiResponse<Void> oauthRegister(
 		@RequestBody @Valid OAuthRegisterRequest oAuthRegisterRequest) {
 		authService.oauthRegister(oAuthRegisterRequest);
-		return ResponseEntity.ok(ApiResponse.noContent());
+		return ApiResponse.noContent();
 	}
 
 	@PostMapping("/reissue")
 	@Operation(
 		summary = "토큰 재발급 API",
 		description = "리프레시 토큰으로 새로운 액세스 토큰 발급")
-	public ResponseEntity<ApiResponse<Void>> reissue(
+	public ApiResponse<Void> reissue(
 		@CookieValue("Refresh-Token") final String refreshToken,
 		HttpServletResponse response) {
 		authService.reissue(refreshToken, response);
-		return ResponseEntity.ok(ApiResponse.noContent());
+		return ApiResponse.noContent();
 	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
@@ -3,7 +3,6 @@ package doldol_server.doldol.rollingPaper.controller;
 import java.time.LocalDateTime;
 
 import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -43,7 +42,7 @@ public class MessageController {
 		summary = "메세지 리스트 조회 API",
 		description = "메세지 리스트 조회",
 		security = {@SecurityRequirement(name = "jwt")})
-	public ResponseEntity<ApiResponse<MessageListResponse>> getMessages(
+	public ApiResponse<MessageListResponse> getMessages(
 		@RequestParam("paperId") Long paperId,
 		@Parameter(description = "메시지 타입: RECEIVE(송신) 또는 SEND(발신)")
 		@RequestParam(defaultValue = "SEND") MessageType messageType,
@@ -53,7 +52,7 @@ public class MessageController {
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		MessageListResponse messages = messageService.getMessages(paperId, messageType, openDate, request,
 			userDetails.getUserId());
-		return ResponseEntity.ok(ApiResponse.ok(messages));
+		return ApiResponse.ok(messages);
 	}
 
 	@PostMapping
@@ -61,11 +60,11 @@ public class MessageController {
 		summary = "메세지 작성 API",
 		description = "메세지 작성",
 		security = {@SecurityRequirement(name = "jwt")})
-	public ResponseEntity<ApiResponse<Void>> createMessage(
+	public ApiResponse<Void> createMessage(
 		@RequestBody @Valid CreateMessageRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		messageService.createMessage(request, userDetails.getUserId());
-		return ResponseEntity.ok(ApiResponse.noContent());
+		return ApiResponse.noContent();
 	}
 
 	@PatchMapping
@@ -73,11 +72,11 @@ public class MessageController {
 		summary = "메세지 수정 API",
 		description = "메세지 수정",
 		security = {@SecurityRequirement(name = "jwt")})
-	public ResponseEntity<ApiResponse<Void>> updateMessage(
+	public ApiResponse<Void> updateMessage(
 		@RequestBody @Valid UpdateMessageRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		messageService.updateMessage(request, userDetails.getUserId());
-		return ResponseEntity.ok(ApiResponse.noContent());
+		return ApiResponse.noContent();
 	}
 
 	@DeleteMapping
@@ -85,10 +84,10 @@ public class MessageController {
 		summary = "메세지 삭제 API",
 		description = "메세지 삭제",
 		security = {@SecurityRequirement(name = "jwt")})
-	public ResponseEntity<ApiResponse<Void>> deleteMessage(
+	public ApiResponse<Void> deleteMessage(
 		@ParameterObject @RequestBody @Valid DeleteMessageRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		messageService.deleteMessage(request, userDetails.getUserId());
-		return ResponseEntity.ok(ApiResponse.noContent());
+		return ApiResponse.noContent();
 	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/request/UpdateMessageRequest.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/request/UpdateMessageRequest.java
@@ -10,19 +10,15 @@ public record UpdateMessageRequest(
 	@Schema(description = "수정할 메세지 ID", example = "1")
 	Long messageId,
 
-	@NotBlank(message = "글씨체가 입력되어야 합니다.")
 	@Schema(description = "글씨체", example = "프리텐다드")
 	String fontStyle,
 
-	@NotBlank(message = "배경 색상 입력되어야 합니다.")
 	@Schema(description = "배경 색상", example = "#000000")
 	String backgroundColor,
 
-	@NotBlank(message = "메세지 내용이 입력되어야 합니다.")
 	@Schema(description = "메세지 내용", example = "가나다라마바사")
 	String content,
 
-	@NotBlank(message = "보내는 사람 이름이 입력되어야 합니다.")
 	@Schema(description = "보내는 사람 이름", example = "돌돌")
 	String fromName
 ) {

--- a/src/main/java/doldol_server/doldol/rollingPaper/entity/Message.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/entity/Message.java
@@ -65,14 +65,23 @@ public class Message extends BaseEntity {
 		this.to = to;
 	}
 
-	public void update(String fontStyle, String backgroundColor, String content, String from) {
+	public void updateDeleteStatus() {
+		this.isDeleted = true;
+	}
+
+	public void updateContent(String content) {
 		this.content = content;
-		this.name = from;
+	}
+
+	public void updateFontStyle(String fontStyle) {
 		this.fontStyle = fontStyle;
+	}
+
+	public void updateBackgroundColor(String backgroundColor) {
 		this.backgroundColor = backgroundColor;
 	}
 
-	public void updateDeleteStatus() {
-		this.isDeleted = true;
+	public void updateName(String fromName) {
+		this.name = fromName;
 	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/MessageService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/MessageService.java
@@ -89,7 +89,7 @@ public class MessageService {
 			throw new CustomException(MessageErrorCode.MESSAGE_NOT_FOUND);
 		}
 
-		message.update(request.fontStyle(), request.backgroundColor(), request.content(), request.fromName());
+		conditionalUpdate(request, message);
 	}
 
 	@Transactional
@@ -110,5 +110,20 @@ public class MessageService {
 
 	private Long getSentMessageCounts(Long paperId, Long userId) {
 		return messageRepository.getSentdMessagesCount(paperId, userId);
+	}
+
+	private static void conditionalUpdate(UpdateMessageRequest request, Message message) {
+		if (request.content() != null) {
+			message.updateContent(request.content());
+		}
+		if (request.fontStyle() != null) {
+			message.updateFontStyle(request.fontStyle());
+		}
+		if (request.backgroundColor() != null) {
+			message.updateBackgroundColor(request.backgroundColor());
+		}
+		if (request.fromName() != null) {
+			message.updateName(request.fromName());
+		}
 	}
 }


### PR DESCRIPTION
## 📄 PR 내용

- 메시지 수정 시 일부 데이터는 null로 옵니다. 이에 대한 조건문 업데이트를 실행합니다.
- 컨트롤러의 응답값을 ApiResponse로만 전달합니다.

## 📝 수정 상세 내용 

- 메시지 수정 시 일부 데이터는 null로 옵니다. 이에 대한 조건문 업데이트를 실행
- 컨트롤러의 응답값을 ApiResponse로만 전달

## ✅ 체크리스트

- [ ] 메시지 수정 시 일부 데이터는 null로 옵니다. 이에 대한 조건문 업데이트를 실행
- [ ] 컨트롤러의 응답값을 ApiResponse로만 전달

## 📍 레퍼런스

- X