### PR TITLE
[FEAT] 회원 탈퇴

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
 
 ext {
     queryDslVersion = "5.1.0"
+    springCloudVersion = "2024.0.1"
 }
 
 group = 'doldol_server'
@@ -81,6 +82,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.1"
+
+    // OpenFeign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 tasks.named('test') {
@@ -91,6 +95,11 @@ def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
 
 sourceSets {
     main.java.srcDirs += [querydslDir]
+}
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion"
+    }
 }
 
 clean.doLast {

--- a/src/main/java/doldol_server/doldol/DoldolApplication.java
+++ b/src/main/java/doldol_server/doldol/DoldolApplication.java
@@ -2,7 +2,9 @@ package doldol_server.doldol;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class DoldolApplication {
 

--- a/src/main/java/doldol_server/doldol/auth/controller/AuthController.java
+++ b/src/main/java/doldol_server/doldol/auth/controller/AuthController.java
@@ -18,6 +18,7 @@ import doldol_server.doldol.auth.dto.request.RegisterRequest;
 import doldol_server.doldol.auth.service.AuthService;
 import doldol_server.doldol.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -113,7 +114,8 @@ public class AuthController {
 	@PostMapping("/withdraw")
 	@Operation(
 		summary = "회원 탈퇴 API",
-		description = "회원 탈퇴")
+		description = "회원 탈퇴",
+		security = {@SecurityRequirement(name = "jwt")})
 	public ApiResponse<Void> withdraw(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		HttpServletResponse response) {

--- a/src/main/java/doldol_server/doldol/auth/controller/AuthController.java
+++ b/src/main/java/doldol_server/doldol/auth/controller/AuthController.java
@@ -1,11 +1,13 @@
 package doldol_server.doldol.auth.controller;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import doldol_server.doldol.auth.dto.CustomUserDetails;
 import doldol_server.doldol.auth.dto.request.EmailCheckRequest;
 import doldol_server.doldol.auth.dto.request.EmailCodeSendRequest;
 import doldol_server.doldol.auth.dto.request.EmailCodeVerifyRequest;
@@ -105,6 +107,17 @@ public class AuthController {
 		@CookieValue("Refresh-Token") final String refreshToken,
 		HttpServletResponse response) {
 		authService.reissue(refreshToken, response);
+		return ApiResponse.noContent();
+	}
+
+	@PostMapping("/withdraw")
+	@Operation(
+		summary = "회원 탈퇴 API",
+		description = "회원 탈퇴")
+	public ApiResponse<Void> withdraw(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		HttpServletResponse response) {
+		authService.withdraw(userDetails.getUserId(), response);
 		return ApiResponse.noContent();
 	}
 }

--- a/src/main/java/doldol_server/doldol/auth/dto/OAuth2ResponseStrategy.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/OAuth2ResponseStrategy.java
@@ -6,4 +6,6 @@ public interface OAuth2ResponseStrategy {
 	String getProviderType();
 
 	OAuth2Response createResponse(Map<String, Object> attributes);
+
+	void unlink(String socialId);
 }

--- a/src/main/java/doldol_server/doldol/auth/dto/kakao/KakaoApiClient.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/kakao/KakaoApiClient.java
@@ -1,0 +1,19 @@
+package doldol_server.doldol.auth.dto.kakao;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@ComponentScan
+@FeignClient(name = "kakaoApiClient", url = "https://kapi.kakao.com")
+public interface KakaoApiClient {
+
+	@PostMapping(value = "/v1/user/unlink", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+	void withdraw(@RequestHeader(HttpHeaders.AUTHORIZATION) String key,
+		@RequestParam("target_id_type") String type,
+		@RequestParam("target_id") Long id);
+}

--- a/src/main/java/doldol_server/doldol/auth/dto/kakao/KakaoOAuth2Strategy.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/kakao/KakaoOAuth2Strategy.java
@@ -7,9 +7,14 @@ import org.springframework.stereotype.Component;
 
 import doldol_server.doldol.auth.dto.OAuth2Response;
 import doldol_server.doldol.auth.dto.OAuth2ResponseStrategy;
+import doldol_server.doldol.common.exception.OAuth2UnlinkException;
+import doldol_server.doldol.common.exception.errorCode.OAuth2ErrorCode;
 import doldol_server.doldol.user.entity.SocialType;
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class KakaoOAuth2Strategy implements OAuth2ResponseStrategy {
@@ -32,10 +37,29 @@ public class KakaoOAuth2Strategy implements OAuth2ResponseStrategy {
 		return new KakaoResponse(attributes);
 	}
 
+
 	@Override
 	public void unlink(String socialId) {
-		kakaoApiClient.withdraw(KAKAO_ADMIN_KEY + adminKey,
-			KAKAO_TARGET_TYPE,
-			Long.parseLong(socialId));
+		try {
+			kakaoApiClient.withdraw(KAKAO_ADMIN_KEY + adminKey,
+				KAKAO_TARGET_TYPE,
+				Long.parseLong(socialId));
+			log.info("카카오 사용자 연결 해제 성공. socialId: {}", socialId);
+		} catch (NumberFormatException e) {
+			log.error("카카오 연결 해제 중 잘못된 socialId 형식. socialId: {}", socialId, e);
+			throw new OAuth2UnlinkException(OAuth2ErrorCode.INVALID_SOCIAL_ID);
+		} catch (FeignException.Unauthorized e) {
+			log.error("카카오 API 인증 실패. 관리자 키를 확인하세요. socialId: {}", socialId, e);
+			throw new OAuth2UnlinkException(OAuth2ErrorCode.OAUTH2_UNAUTHORIZED);
+		} catch (FeignException.BadRequest e) {
+			log.error("카카오 API 잘못된 요청. 유효하지 않은 socialId 또는 파라미터. socialId: {}", socialId, e);
+			throw new OAuth2UnlinkException(OAuth2ErrorCode.OAUTH2_BAD_REQUEST);
+		} catch (FeignException e) {
+			log.error("카카오 API 호출 실패. 상태코드: {}, socialId: {}", e.status(), socialId, e);
+			throw new OAuth2UnlinkException(OAuth2ErrorCode.OAUTH2_API_ERROR);
+		} catch (Exception e) {
+			log.error("카카오 연결 해제 중 예상치 못한 오류 발생. socialId: {}", socialId, e);
+			throw new OAuth2UnlinkException(OAuth2ErrorCode.OAUTH2_UNLINK_FAILED);
+		}
 	}
 }

--- a/src/main/java/doldol_server/doldol/auth/dto/kakao/KakaoOAuth2Strategy.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/kakao/KakaoOAuth2Strategy.java
@@ -2,14 +2,25 @@ package doldol_server.doldol.auth.dto.kakao;
 
 import java.util.Map;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import doldol_server.doldol.auth.dto.OAuth2Response;
 import doldol_server.doldol.auth.dto.OAuth2ResponseStrategy;
 import doldol_server.doldol.user.entity.SocialType;
+import lombok.RequiredArgsConstructor;
 
 @Component
+@RequiredArgsConstructor
 public class KakaoOAuth2Strategy implements OAuth2ResponseStrategy {
+
+	private static final String KAKAO_ADMIN_KEY = "KakaoAK ";
+	private static final String KAKAO_TARGET_TYPE = "user_id";
+
+	private final KakaoApiClient kakaoApiClient;
+
+	@Value("${admin-key.kakao}")
+	private String adminKey;
 
 	@Override
 	public String getProviderType() {
@@ -19,5 +30,12 @@ public class KakaoOAuth2Strategy implements OAuth2ResponseStrategy {
 	@Override
 	public OAuth2Response createResponse(Map<String, Object> attributes) {
 		return new KakaoResponse(attributes);
+	}
+
+	@Override
+	public void unlink(String socialId) {
+		kakaoApiClient.withdraw(KAKAO_ADMIN_KEY + adminKey,
+			KAKAO_TARGET_TYPE,
+			Long.parseLong(socialId));
 	}
 }

--- a/src/main/java/doldol_server/doldol/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/doldol_server/doldol/auth/filter/JwtAuthenticationFilter.java
@@ -26,6 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final TokenProvider tokenProvider;
     private final String[] whiteList;
+    private final String[] blackList;
     private final ObjectMapper objectMapper;
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
@@ -61,6 +62,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String requestURI = request.getRequestURI();
+
+        boolean isInBlackList = Arrays.stream(blackList)
+            .anyMatch(pattern -> pathMatcher.match(pattern, requestURI));
+
+        if (isInBlackList) {
+            return false;
+        }
 
         return Arrays.stream(whiteList)
                 .anyMatch(pattern -> pathMatcher.match(pattern, requestURI));

--- a/src/main/java/doldol_server/doldol/auth/service/AuthService.java
+++ b/src/main/java/doldol_server/doldol/auth/service/AuthService.java
@@ -12,6 +12,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import doldol_server.doldol.auth.dto.OAuth2ResponseStrategy;
 import doldol_server.doldol.auth.dto.request.OAuthRegisterRequest;
 import doldol_server.doldol.auth.dto.request.RegisterRequest;
 import doldol_server.doldol.auth.jwt.TokenProvider;
@@ -44,6 +45,7 @@ public class AuthService {
 	private final RedisTemplate<String, String> redisTemplate;
 	private final PasswordEncoder passwordEncoder;
 	private final TokenProvider tokenProvider;
+	private final OAuthSeperator oAuthSeperator;
 
 	public void checkIdDuplicate(String id) {
 		boolean isIdExists = userRepository.existsByLoginId(id);
@@ -169,6 +171,11 @@ public class AuthService {
 
 		if (user.isDeleted()) {
 			throw new CustomException(AuthErrorCode.ALREADY_WITHDRAWN);
+		}
+
+		if (user.getSocialId() != null) {
+			OAuth2ResponseStrategy strategy = oAuthSeperator.getStrategy(user.getSocialType().name());
+			strategy.unlink(user.getSocialId());
 		}
 
 		user.updateDeleteStatus();

--- a/src/main/java/doldol_server/doldol/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/doldol_server/doldol/auth/service/CustomOAuth2UserService.java
@@ -45,8 +45,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 		OAuth2Response oAuth2Response = oAuthSeperator.createResponse(registrationId, oAuth2User.getAttributes());
 
 		Optional<User> socialLinkedUser = userRepository.findBySocialId(oAuth2Response.getSocialId());
-		if (socialLinkedUser.isPresent()) {
+
+		if (socialLinkedUser.isPresent() && !socialLinkedUser.get().isDeleted()) {
 			return handleExistingUser(socialLinkedUser.get(), oAuth2User, oAuth2Response.getSocialId());
+		}
+
+		else if (socialLinkedUser.isPresent() && socialLinkedUser.get().isDeleted()) {
+			throw new CustomOAuth2Exception(AuthErrorCode.ALREADY_WITHDRAWN);
 		}
 
 		if (isAccountLinking) {

--- a/src/main/java/doldol_server/doldol/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/doldol_server/doldol/auth/service/CustomUserDetailsService.java
@@ -19,7 +19,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public CustomUserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
-        Optional<User> user = userRepository.findByLoginId(loginId);
+        Optional<User> user = userRepository.findByLoginIdAndIsDeletedFalse(loginId);
 
         if (user.isPresent()) {
             User loginUser = user.get();

--- a/src/main/java/doldol_server/doldol/auth/service/OAuthSeperator.java
+++ b/src/main/java/doldol_server/doldol/auth/service/OAuthSeperator.java
@@ -30,4 +30,8 @@ public class OAuthSeperator {
 
         return strategy.createResponse(attributes);
     }
+
+    public OAuth2ResponseStrategy getStrategy(String providerType) {
+        return strategies.get(providerType);
+    }
 }

--- a/src/main/java/doldol_server/doldol/auth/util/CookieUtil.java
+++ b/src/main/java/doldol_server/doldol/auth/util/CookieUtil.java
@@ -1,5 +1,6 @@
 package doldol_server.doldol.auth.util;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 
 import jakarta.servlet.http.Cookie;
@@ -10,11 +11,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class CookieUtil {
 
+    @Value("${cookie.same-site}")
+    private static String sameSite;
+
     public static ResponseCookie createCookie(String name, String value, long cookieExpiration) {
         return ResponseCookie.from(name, value)
             .maxAge(cookieExpiration)
             .path("/")
-            .sameSite("Strict")
+            .sameSite(sameSite)
             .httpOnly(true)
             .build();
     }

--- a/src/main/java/doldol_server/doldol/common/config/SecurityConfig.java
+++ b/src/main/java/doldol_server/doldol/common/config/SecurityConfig.java
@@ -42,9 +42,13 @@ public class SecurityConfig {
 		"/papers/invite"
 	};
 
+	private static final String[] BLACKLIST = {
+		"/auth/logout",
+		"/auth/withdraw"
+	};
+
 	private final TokenProvider tokenProvider;
 	private final ObjectMapper objectMapper;
-	private final CorsConfigurationSource corsConfigurationSource;
 	private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
 	private final CustomOAuth2FailureHandler customOAuth2FailureHandler;
 	private final CustomOAuth2UserService customOAuth2UserService;
@@ -71,10 +75,11 @@ public class SecurityConfig {
 			)
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(WHITELIST).permitAll()
+				.requestMatchers(BLACKLIST).authenticated()
 				.anyRequest().authenticated())
 			.addFilterAt(new CustomUserLoginFilter(authenticationManager, tokenProvider, objectMapper),
 				UsernamePasswordAuthenticationFilter.class)
-			.addFilterAfter(new JwtAuthenticationFilter(tokenProvider, WHITELIST, objectMapper),
+			.addFilterAfter(new JwtAuthenticationFilter(tokenProvider, WHITELIST, BLACKLIST, objectMapper),
 				CustomUserLoginFilter.class)
 			.addFilterBefore(new CustomLogoutFilter(tokenProvider, objectMapper), LogoutFilter.class)
 

--- a/src/main/java/doldol_server/doldol/common/config/SecurityConfig.java
+++ b/src/main/java/doldol_server/doldol/common/config/SecurityConfig.java
@@ -11,7 +11,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
-import org.springframework.web.cors.CorsConfigurationSource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -25,6 +24,7 @@ import doldol_server.doldol.auth.handler.CustomOAuth2SuccessHandler;
 import doldol_server.doldol.auth.jwt.TokenProvider;
 import doldol_server.doldol.auth.resolver.CustomOAuth2ParameterResolver;
 import doldol_server.doldol.auth.service.CustomOAuth2UserService;
+import doldol_server.doldol.user.entity.Role;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -76,6 +76,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(WHITELIST).permitAll()
 				.requestMatchers(BLACKLIST).authenticated()
+				.requestMatchers("/auth/withdraw").hasRole(Role.ADMIN.name())
 				.anyRequest().authenticated())
 			.addFilterAt(new CustomUserLoginFilter(authenticationManager, tokenProvider, objectMapper),
 				UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/doldol_server/doldol/common/exception/OAuth2UnlinkException.java
+++ b/src/main/java/doldol_server/doldol/common/exception/OAuth2UnlinkException.java
@@ -1,0 +1,19 @@
+package doldol_server.doldol.common.exception;
+
+import doldol_server.doldol.common.exception.errorCode.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class OAuth2UnlinkException extends RuntimeException {
+    private final ErrorCode errorCode;
+    
+    public OAuth2UnlinkException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+    
+    public OAuth2UnlinkException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/doldol_server/doldol/common/exception/errorCode/AuthErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/errorCode/AuthErrorCode.java
@@ -10,6 +10,7 @@ public enum AuthErrorCode implements ErrorCode {
 
     // 400
     VERIFICATION_CODE_WRONG(HttpStatus.BAD_REQUEST, "A-009", "인증번호가 틀렸습니다."),
+    ALREADY_WITHDRAWN(HttpStatus.BAD_REQUEST, "U010", "이미 탈퇴한 사용자입니다."),
 
     // 401
     WRONG_ID_PW(HttpStatus.UNAUTHORIZED, "A-001", "아이디 혹은 비밀번호가 올바르지 않습니다."),

--- a/src/main/java/doldol_server/doldol/common/exception/errorCode/OAuth2ErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/errorCode/OAuth2ErrorCode.java
@@ -1,0 +1,20 @@
+package doldol_server.doldol.common.exception.errorCode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuth2ErrorCode implements ErrorCode {
+    INVALID_SOCIAL_ID(HttpStatus.BAD_REQUEST, "OA-001", "유효하지 않은 소셜 ID입니다."),
+    OAUTH2_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "OA-002", "OAuth2 인증에 실패했습니다."),
+    OAUTH2_BAD_REQUEST(HttpStatus.BAD_REQUEST, "OA-003", "OAuth2 요청이 잘못되었습니다."),
+    OAUTH2_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "OA-004", "OAuth2 API 호출에 실패했습니다."),
+    OAUTH2_UNLINK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OA-005", "OAuth2 연결 해제에 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/doldol_server/doldol/user/entity/User.java
+++ b/src/main/java/doldol_server/doldol/user/entity/User.java
@@ -78,4 +78,8 @@ public class User extends BaseEntity {
 	public void updateUserPassword(String password) {
 		this.password = password;
 	}
+
+	public void updateDeleteStatus() {
+		this.isDeleted = true;
+	}
 }

--- a/src/main/java/doldol_server/doldol/user/repository/UserRepository.java
+++ b/src/main/java/doldol_server/doldol/user/repository/UserRepository.java
@@ -8,7 +8,7 @@ import doldol_server.doldol.user.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-	Optional<User> findByLoginId(String loginId);
+	Optional<User> findByLoginIdAndIsDeletedFalse(String loginId);
 
 	Optional<User> findBySocialId(String socialId);
 

--- a/src/test/java/doldol_server/doldol/auth/controller/AuthControllerTest.java
+++ b/src/test/java/doldol_server/doldol/auth/controller/AuthControllerTest.java
@@ -381,4 +381,20 @@ class AuthControllerTest extends ControllerTest {
 
 		verify(authService, never()).reissue(anyString(), any(HttpServletResponse.class));
 	}
+
+	@Test
+	@DisplayName("회원 탈퇴 - 성공")
+	void withdraw_Success() throws Exception {
+		// given
+		Long userId = 1L;
+		doNothing().when(authService).withdraw(anyLong(), any(HttpServletResponse.class));
+
+		// when & then
+		mockMvc.perform(post("/auth/withdraw")
+				.with(mockUser(userId))) // ControllerTest의 mockUser 메서드 사용
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(204));
+
+		verify(authService).withdraw(eq(userId), any(HttpServletResponse.class));
+	}
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -85,3 +85,6 @@ cors:
 paper:
   default:
     link: http://localhost:8080/paper?code=
+
+admin-key:
+  kakao: keykeykeykeykeykeykeykeykeykeykey

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -88,3 +88,6 @@ paper:
 
 admin-key:
   kakao: keykeykeykeykeykeykeykeykeykeykey
+
+cookie:
+  same-site: None


### PR DESCRIPTION
## 📄 PR 내용

- 회원 탈퇴 시 사용자의 isDeleted 상태를 true로 업데이트 하였습니다.
- 소셜 연동/회원가입 한 사용자의 소셜 플랫폼과 OpenFeign을 이용해서 연결 끊기를 진행했습니다.

## 📝 수정 상세 내용 

- 회원 탈퇴 시 사용자의 isDeleted 상태를 true로 업데이트
- 소셜 연동/회원가입 한 사용자의 소셜 플랫폼과 OpenFeign을 이용해서 연결 끊기

## ✅ 체크리스트

- [X] 회원 탈퇴 시 사용자의 isDeleted 상태를 true로 업데이트
- [X] 소셜 연동/회원가입 한 사용자의 소셜 플랫폼과 OpenFeign을 이용해서 연결 끊기

## 📍 레퍼런스

- [카카오 공식 문서](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#unlink)
- [OpenFeign이란](https://mangkyu.tistory.com/278)