### PR TITLE
[REFACTOR] 로그인 성공 후 토큰 Body에 탑재

### DIFF
--- a/src/main/java/doldol_server/doldol/auth/controller/AuthController.java
+++ b/src/main/java/doldol_server/doldol/auth/controller/AuthController.java
@@ -19,13 +19,13 @@ import doldol_server.doldol.auth.dto.request.OAuthRegisterRequest;
 import doldol_server.doldol.auth.dto.request.PhoneCheckRequest;
 import doldol_server.doldol.auth.dto.request.RegisterRequest;
 import doldol_server.doldol.auth.dto.request.UserInfoIdCheckRequest;
+import doldol_server.doldol.auth.dto.response.ReissueTokenResponse;
 import doldol_server.doldol.auth.dto.response.UserLoginIdResponse;
 import doldol_server.doldol.auth.service.AuthService;
 import doldol_server.doldol.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -109,11 +109,10 @@ public class AuthController {
 	@Operation(
 		summary = "토큰 재발급 API",
 		description = "리프레시 토큰으로 새로운 액세스 토큰 발급")
-	public ApiResponse<Void> reissue(
-		@CookieValue("Refresh-Token") final String refreshToken,
-		HttpServletResponse response) {
-		authService.reissue(refreshToken, response);
-		return ApiResponse.noContent();
+	public ApiResponse<ReissueTokenResponse> reissue(
+		@CookieValue("Refresh-Token") final String refreshToken) {
+		ReissueTokenResponse reissueTokenResponse = authService.reissue(refreshToken);
+		return ApiResponse.ok(reissueTokenResponse);
 	}
 
 	@PostMapping("/withdraw")
@@ -122,9 +121,8 @@ public class AuthController {
 		description = "회원 탈퇴",
 		security = {@SecurityRequirement(name = "jwt")})
 	public ApiResponse<Void> withdraw(
-		@AuthenticationPrincipal CustomUserDetails userDetails,
-		HttpServletResponse response) {
-		authService.withdraw(userDetails.getUserId(), response);
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		authService.withdraw(userDetails.getUserId());
 		return ApiResponse.noContent();
 	}
 

--- a/src/main/java/doldol_server/doldol/auth/dto/response/ReissueTokenResponse.java
+++ b/src/main/java/doldol_server/doldol/auth/dto/response/ReissueTokenResponse.java
@@ -5,12 +5,8 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
-@Schema(name = "LoginResponse: 로그인 응답 Dto")
-public record LoginResponse(
-	@Schema(description = "유저 식별 값입니다,", example = "1")
-	Long userId,
-	@Schema(description = "로그인 성공한 유저의 권한입니다.", example = "ADMIN")
-	String role,
+@Schema(name = "ReissueTokenResponse: 재발급 토큰 응답 Dto")
+public record ReissueTokenResponse(
 	@NotNull
 	@Schema(description = "JWT Access 토큰입니다.", example = "access-token")
 	String accessToken,

--- a/src/main/java/doldol_server/doldol/auth/filter/CustomLogoutFilter.java
+++ b/src/main/java/doldol_server/doldol/auth/filter/CustomLogoutFilter.java
@@ -1,10 +1,14 @@
 package doldol_server.doldol.auth.filter;
 
-import static doldol_server.doldol.common.constants.CookieConstant.*;
+import java.io.IOException;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.GenericFilterBean;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import doldol_server.doldol.auth.jwt.TokenProvider;
-import doldol_server.doldol.auth.util.CookieUtil;
 import doldol_server.doldol.auth.util.ResponseUtil;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
@@ -13,13 +17,7 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
-import org.springframework.web.filter.GenericFilterBean;
 
 @RequiredArgsConstructor
 public class CustomLogoutFilter extends GenericFilterBean {
@@ -48,12 +46,6 @@ public class CustomLogoutFilter extends GenericFilterBean {
         String id = claimsByAccessToken.getSubject();
 
         tokenProvider.deleteRefreshToken(id);
-
-        ResponseCookie accessTokenCookie = CookieUtil.createCookie(ACCESS_TOKEN_COOKIE_NAME, null, TOKEN_EXPIRATION_DELETE);
-        ResponseCookie refreshTokenCookie = CookieUtil.createCookie(REFRESH_TOKEN_COOKIE_NAME, null, TOKEN_EXPIRATION_DELETE);
-
-        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
-        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
         ResponseUtil.writeNoContent(
                 response,

--- a/src/main/java/doldol_server/doldol/auth/filter/CustomUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/doldol_server/doldol/auth/filter/CustomUsernamePasswordAuthenticationFilter.java
@@ -1,15 +1,10 @@
 package doldol_server.doldol.auth.filter;
 
-import static doldol_server.doldol.common.constants.CookieConstant.*;
-import static doldol_server.doldol.common.constants.TokenConstant.*;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -25,7 +20,6 @@ import doldol_server.doldol.auth.dto.request.LoginRequest;
 import doldol_server.doldol.auth.dto.response.LoginResponse;
 import doldol_server.doldol.auth.jwt.TokenProvider;
 import doldol_server.doldol.auth.jwt.dto.UserTokenResponse;
-import doldol_server.doldol.auth.util.CookieUtil;
 import doldol_server.doldol.auth.util.ResponseUtil;
 import doldol_server.doldol.common.exception.errorCode.AuthErrorCode;
 import jakarta.servlet.FilterChain;
@@ -90,22 +84,9 @@ public abstract class CustomUsernamePasswordAuthenticationFilter extends Usernam
 		LoginResponse loginResponse = LoginResponse.builder()
 			.userId(userDetails.getUserId())
 			.role(role)
+			.accessToken(loginToken.accessToken())
+			.refreshToken(loginToken.refreshToken())
 			.build();
-
-		ResponseCookie accessTokenCookie = CookieUtil.createCookie(
-			ACCESS_TOKEN_COOKIE_NAME,
-			loginToken.accessToken(),
-			ACCESS_TOKEN_EXPIRATION_MINUTE * MINUTE_IN_MILLISECONDS
-		);
-
-		ResponseCookie refreshTokenCookie = CookieUtil.createCookie(
-			REFRESH_TOKEN_COOKIE_NAME,
-			loginToken.refreshToken(),
-			REFRESH_TOKEN_EXPIRATION_DAYS * DAYS_IN_MILLISECONDS
-		);
-
-		response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
-		response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
 		ResponseUtil.writeSuccessResponseWithHeaders(
 			response,

--- a/src/main/java/doldol_server/doldol/auth/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/doldol_server/doldol/auth/handler/CustomOAuth2SuccessHandler.java
@@ -1,8 +1,5 @@
 package doldol_server.doldol.auth.handler;
 
-import static doldol_server.doldol.common.constants.CookieConstant.*;
-import static doldol_server.doldol.common.constants.TokenConstant.*;
-
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -10,7 +7,6 @@ import java.nio.charset.StandardCharsets;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -23,7 +19,6 @@ import doldol_server.doldol.auth.dto.CustomUserDetails;
 import doldol_server.doldol.auth.dto.response.LoginResponse;
 import doldol_server.doldol.auth.jwt.TokenProvider;
 import doldol_server.doldol.auth.jwt.dto.UserTokenResponse;
-import doldol_server.doldol.auth.util.CookieUtil;
 import doldol_server.doldol.auth.util.ResponseUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -82,23 +77,11 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 		LoginResponse loginResponse = LoginResponse.builder()
 			.userId(userDetails.getUserId())
 			.role(userDetails.getRole())
+			.accessToken(loginToken.accessToken())
+			.refreshToken(loginToken.refreshToken())
 			.build();
 
-		ResponseCookie accessTokenCookie = CookieUtil.createCookie(
-			ACCESS_TOKEN_COOKIE_NAME,
-			loginToken.accessToken(),
-			ACCESS_TOKEN_EXPIRATION_MINUTE * MINUTE_IN_MILLISECONDS
-		);
-
-		ResponseCookie refreshTokenCookie = CookieUtil.createCookie(
-			REFRESH_TOKEN_COOKIE_NAME,
-			loginToken.refreshToken(),
-			REFRESH_TOKEN_EXPIRATION_DAYS * DAYS_IN_MILLISECONDS
-		);
-
 		response.addHeader(HttpHeaders.LOCATION, loginSuccessRedirectUrl);
-		response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
-		response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
 		ResponseUtil.writeSuccessResponseWithHeaders(
 			response,

--- a/src/main/java/doldol_server/doldol/auth/util/CookieUtil.java
+++ b/src/main/java/doldol_server/doldol/auth/util/CookieUtil.java
@@ -1,8 +1,5 @@
 package doldol_server.doldol.auth.util;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseCookie;
-
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.AccessLevel;
@@ -10,22 +7,6 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class CookieUtil {
-
-    @Value("${cookie.same-site}")
-    private static String sameSite;
-
-    @Value("${cookie.domain}")
-    private static String domain;
-
-    public static ResponseCookie createCookie(String name, String value, long cookieExpiration) {
-        return ResponseCookie.from(name, value)
-            .maxAge(cookieExpiration)
-            .path("/")
-            .domain("localhost:3000")
-            .sameSite(sameSite)
-            .httpOnly(true)
-            .build();
-    }
 
     public static String getCookieValue(HttpServletRequest request, String name) {
         Cookie cookie = findCookieByName(request, name);


### PR DESCRIPTION
## 📄 PR 내용

- 로그인 성공 후 jwt 토큰을 response body 전송으로 변경했습니다.
- 소셜 로그인 성공 후 정보들을 쿼리파라미터로 담았습니다. (프론트측의 개발을 위한 임시방편, 추후 변경)

## 📝 수정 상세 내용 

- LoginResponse Dto에 jwt 토큰 필드를 세팅 후 응답값으로 전송
- OAuthhSuccessHandler에서 쿼리파라미터로 같이 담아서 전송


## ✅ 체크리스트

- [X] LoginResponse Dto에 jwt 토큰 필드를 세팅 후 응답값으로 전송
- [X] OAuthhSuccessHandler에서 쿼리파라미터로 같이 담아서 전송



## 📍 레퍼런스

- X