### PR TITLE
[REFACTOR] 신고 컨트롤러 분리, 스웨거 반영

### DIFF
--- a/src/main/java/doldol_server/doldol/common/config/SecurityConfig.java
+++ b/src/main/java/doldol_server/doldol/common/config/SecurityConfig.java
@@ -79,7 +79,7 @@ public class SecurityConfig {
 				.requestMatchers(BLACKLIST).authenticated()
 
 				.requestMatchers(HttpMethod.POST, "/reports").hasAuthority(Role.USER.getRole())
-				.requestMatchers("/auth/withdraw", "/reports/**").hasAuthority(Role.ADMIN.getRole())
+				.requestMatchers("/auth/withdraw", "/admin/reports/**").hasAuthority(Role.ADMIN.getRole())
 				.anyRequest().authenticated())
 			.addFilterAt(new CustomUserLoginFilter(authenticationManager, tokenProvider, objectMapper),
 				UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/doldol_server/doldol/report/controller/AdminReportController.java
+++ b/src/main/java/doldol_server/doldol/report/controller/AdminReportController.java
@@ -4,8 +4,6 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,7 +11,6 @@ import doldol_server.doldol.auth.dto.CustomUserDetails;
 import doldol_server.doldol.common.dto.CursorPage;
 import doldol_server.doldol.common.request.CursorPageRequest;
 import doldol_server.doldol.common.response.ApiResponse;
-import doldol_server.doldol.report.dto.request.ReportRequest;
 import doldol_server.doldol.report.dto.response.ReportResponse;
 import doldol_server.doldol.report.service.ReportService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,11 +19,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "신고")
+@Tag(name = "관리자 신고")
 @RestController
-@RequestMapping("/reports")
+@RequestMapping("/admin/reports")
 @RequiredArgsConstructor
-public class ReportController {
+public class AdminReportController {
 
 	private final ReportService reportService;
 
@@ -53,17 +50,5 @@ public class ReportController {
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		ReportResponse response = reportService.getReportDetail(reportId, userDetails.getUserId());
 		return ApiResponse.ok(response);
-	}
-
-	@PostMapping
-	@Operation(
-		summary = "신고 작성 API",
-		description = "신고",
-		security = {@SecurityRequirement(name = "jwt")})
-	public ApiResponse<ReportResponse> createMessage(
-		@RequestBody @Valid ReportRequest request,
-		@AuthenticationPrincipal CustomUserDetails userDetails) {
-		ReportResponse response = reportService.createReport(request, userDetails.getUserId());
-		return ApiResponse.created(response);
 	}
 }

--- a/src/main/java/doldol_server/doldol/report/controller/UserReportController.java
+++ b/src/main/java/doldol_server/doldol/report/controller/UserReportController.java
@@ -1,0 +1,39 @@
+package doldol_server.doldol.report.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import doldol_server.doldol.auth.dto.CustomUserDetails;
+import doldol_server.doldol.common.response.ApiResponse;
+import doldol_server.doldol.report.dto.request.ReportRequest;
+import doldol_server.doldol.report.dto.response.ReportResponse;
+import doldol_server.doldol.report.service.ReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "사용자 신고")
+@RestController
+@RequestMapping("/reports")
+@RequiredArgsConstructor
+public class UserReportController {
+
+	private final ReportService reportService;
+
+	@PostMapping
+	@Operation(
+		summary = "신고 작성 API",
+		description = "신고",
+		security = {@SecurityRequirement(name = "jwt")})
+	public ApiResponse<ReportResponse> createMessage(
+		@RequestBody @Valid ReportRequest request,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		ReportResponse response = reportService.createReport(request, userDetails.getUserId());
+		return ApiResponse.created(response);
+	}
+}


### PR DESCRIPTION

## 📄 PR 내용

<!--- 작업에 대한 요약 설명을 작성해 주세요. -->

- 신고 컨트롤러 분리, 스웨거 반영, 엔드포인트 변경

## 📝 수정 상세 내용 

<!--- 작업 전과 후의 변화를 설명해 주세요. -->

- 최근 작업한 신고 API 권한 분리를 Swagger에 반영했습니다.
- API가 분리됨에 따라 컨트롤러 분리의 필요성을 느껴 컨트롤러도 분리했습니다. (유저 신고 컨트롤러 / 관리자 신고 컨트롤러)
- 기존 사용자의 신고 작성과 관리자의 신고 조회 엔드포인트가 같아 직관성이 떨어졌습니다.
- 따라서 관리자의 신고 조회 엔드포인트를 `/auth/reports`로 변경하였습니다.

## ✅ 체크리스트

- [ ] 컨트롤러 분리
- [ ] 스웨거 반영
- [ ] 엔드포인트 변경

## 📍 레퍼런스

- X
