### PR TITLE
[FIX] 소셜 회원가입 유저가 아이디 찾을 시 오류 응답 포맷 변경

### DIFF
--- a/src/main/java/doldol_server/doldol/auth/service/AuthService.java
+++ b/src/main/java/doldol_server/doldol/auth/service/AuthService.java
@@ -197,6 +197,10 @@ public class AuthService {
 
 		User user = userRepository.findByEmail(email);
 
+		if (user.getPassword() == null) {
+			throw new CustomException(AuthErrorCode.OAUTH_LOGIN_USER, user.getSocialType().getDisplayName());
+		}
+
 		String tempPassword = GeneratorRandomUtil.generateRandomString();
 
 		user.updateUserPassword(passwordEncoder.encode(tempPassword));

--- a/src/main/java/doldol_server/doldol/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/doldol_server/doldol/common/exception/GlobalExceptionHandler.java
@@ -28,7 +28,7 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ErrorResponse<Void>> handleCustomException(CustomException e) {
 		ErrorCode errorCode = e.getErrorCode();
 		return ResponseEntity.status(errorCode.getHttpStatus())
-			.body(ErrorResponse.error(errorCode.getCode(), errorCode.getMessage()));
+			.body(ErrorResponse.error(errorCode.getCode(), e.getMessage()));
 	}
 
 	/**

--- a/src/main/java/doldol_server/doldol/common/exception/errorCode/AuthErrorCode.java
+++ b/src/main/java/doldol_server/doldol/common/exception/errorCode/AuthErrorCode.java
@@ -12,7 +12,7 @@ public enum AuthErrorCode implements ErrorCode {
     VERIFICATION_CODE_WRONG(HttpStatus.BAD_REQUEST, "A-009", "인증번호가 틀렸습니다."),
     ALREADY_WITHDRAWN(HttpStatus.BAD_REQUEST, "A-015", "이미 탈퇴한 사용자입니다."),
     INCORRECT_EMAIL_OR_PHONE(HttpStatus.BAD_REQUEST, "A-016", "전화번호 또는 이메일이 일치하지 않습니다."),
-    OAUTH_LOGIN_USER(HttpStatus.BAD_REQUEST, "A-017", "%s로 로그인으로 가입한 회원입니다."),
+    OAUTH_LOGIN_USER(HttpStatus.BAD_REQUEST, "A-017", "%s로 가입한 회원입니다."),
 
     // 401
     WRONG_ID_PW(HttpStatus.UNAUTHORIZED, "A-001", "아이디 혹은 비밀번호가 올바르지 않습니다."),


### PR DESCRIPTION
## 📄 PR 내용

- 소셜 회원가입 유저가 아이디 찾을 시 오류 응답 포맷 변경

## 📝 수정 상세 내용 

- GlobalExceptionHandler body 값 변경

## ✅ 체크리스트

- [X] 소셜 회원가입 유저가 아이디 찾을 시 오류 응답 포맷 변경

## 📍 레퍼런스

- X