### PR TITLE
[FIX] 회원가입 추가정보 중복 검증 api를 white list에 등록

### DIFF
--- a/src/main/java/doldol_server/doldol/common/config/SecurityConfig.java
+++ b/src/main/java/doldol_server/doldol/common/config/SecurityConfig.java
@@ -35,8 +35,7 @@ public class SecurityConfig {
 
 	private static final String[] WHITELIST = {
 		"/auth/check-id",
-		"/auth/check-email",
-		"/auth/check-phone",
+		"/auth/check-register-info",
 		"/auth/email/send-code",
 		"/auth/email/verify-code",
 		"/auth/register",


### PR DESCRIPTION
## 📄 PR 내용

- 회원가입 추가정보 중복 검증 api를 white list에 등록

## 📝 수정 상세 내용 

- Security Config 클래스에 /auth/check-register-info 엔드포인트 추가


## ✅ 체크리스트

- [X] Security Config 클래스에 /auth/check-register-info 엔드포인트 추가

## 📍 레퍼런스

- X