### PR TITLE
[FEAT] 개인용 롤링페이퍼 작성

### DIFF
--- a/src/main/java/doldol_server/doldol/common/config/SecurityConfig.java
+++ b/src/main/java/doldol_server/doldol/common/config/SecurityConfig.java
@@ -50,7 +50,8 @@ public class SecurityConfig {
 		"/swagger-resources/**",
 		"/webjars/**",
 		"/actuator/**",
-		"/papers/invite"
+		"/papers/invite",
+		"/messages/individual"
 	};
 
 	private static final String[] BLACKLIST = {

--- a/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
@@ -1,7 +1,5 @@
 package doldol_server.doldol.rollingPaper.controller;
 
-import java.time.LocalDate;
-
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;

--- a/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
@@ -19,6 +19,7 @@ import doldol_server.doldol.common.request.CursorPageRequest;
 import doldol_server.doldol.common.response.ApiResponse;
 import doldol_server.doldol.rollingPaper.dto.request.CreateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.request.DeleteMessageRequest;
+import doldol_server.doldol.rollingPaper.dto.request.PaperType;
 import doldol_server.doldol.rollingPaper.dto.request.UpdateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.response.MessageListResponse;
 import doldol_server.doldol.rollingPaper.dto.response.MessageResponse;
@@ -67,15 +68,21 @@ public class MessageController {
 		return ApiResponse.ok(messages);
 	}
 
-	@PostMapping
+	@PostMapping("/{paperType}")
 	@Operation(
 		summary = "메세지 작성 API",
 		description = "메세지 작성",
 		security = {@SecurityRequirement(name = "jwt")})
 	public ApiResponse<Void> createMessage(
+		@PathVariable("paperType") String paperTypeStr,
 		@RequestBody @Valid CreateMessageRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
-		messageService.createMessage(request, userDetails.getUserId());
+		PaperType paperType = PaperType.valueOf(paperTypeStr.toUpperCase());
+
+		Long userId = (paperType == PaperType.GROUP && userDetails != null)
+			? userDetails.getUserId()
+			: null;
+		messageService.createMessage(request, paperType, userId);
 		return ApiResponse.noContent();
 	}
 

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/request/PaperRequest.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/request/PaperRequest.java
@@ -15,9 +15,12 @@ public record PaperRequest(
 	@Schema(description = "단체 설명", example = "KB 16회차 짱짱맨 영원하라.")
 	String description,
 
-	@NotNull(message = "메세지 공개 날짜는 필수입니다.")
 	@Schema(description = "메세지 공개 날짜", example = "2025-06-26")
 	@FutureOrPresent(message = "메세지 공개 날짜는 과거일 수 없습니다.")
-	LocalDate openDate
+	LocalDate openDate,
+
+	@NotNull(message = "롤링페이퍼 타입은 필수입니다.")
+	@Schema(description = "롤링페이퍼 타입", example = "GROUP")
+	PaperType paperType
 ) {
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/request/PaperType.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/request/PaperType.java
@@ -1,0 +1,15 @@
+package doldol_server.doldol.rollingPaper.dto.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaperType {
+
+	GROUP("그룹용"),
+	INDIVIDUAL("개인용")
+	;
+
+	private final String displayName;
+}

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/response/PaperResponse.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/response/PaperResponse.java
@@ -31,7 +31,10 @@ public record PaperResponse(
 	LocalDate openDate,
 
 	@Schema(description = "롤링페이퍼 타입", example = "GROUP")
-	PaperType paperType
+	PaperType paperType,
+
+	@Schema(description = "롤링페이퍼 생성자 id", example = "1")
+	Long receiverId
 ) {
 	public static PaperResponse of(Paper paper) {
 		return PaperResponse.builder()

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/response/PaperResponse.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/response/PaperResponse.java
@@ -3,6 +3,7 @@ package doldol_server.doldol.rollingPaper.dto.response;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import doldol_server.doldol.rollingPaper.dto.request.PaperType;
 import doldol_server.doldol.rollingPaper.entity.Paper;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -27,7 +28,10 @@ public record PaperResponse(
 	int messageCount,
 
 	@Schema(description = "메세지 공개 날짜", example = "2025-06-26")
-	LocalDate openDate
+	LocalDate openDate,
+
+	@Schema(description = "롤링페이퍼 타입", example = "GROUP")
+	PaperType paperType
 ) {
 	public static PaperResponse of(Paper paper) {
 		return PaperResponse.builder()
@@ -37,6 +41,7 @@ public record PaperResponse(
 			.participantsCount(paper.getParticipantsCount())
 			.messageCount(paper.getMessageCount())
 			.openDate(paper.getOpenDate())
+			.paperType(paper.getPaperType())
 			.build();
 	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/entity/Paper.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/entity/Paper.java
@@ -32,7 +32,7 @@ public class Paper extends BaseEntity {
 	@Column(name = "description")
 	private String description;
 
-	@Column(name = "open_date", nullable = false)
+	@Column(name = "open_date")
 	private LocalDate openDate;
 
 	@Column(name = "invitation_code", nullable = false)

--- a/src/main/java/doldol_server/doldol/rollingPaper/entity/Paper.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/entity/Paper.java
@@ -3,8 +3,12 @@ package doldol_server.doldol.rollingPaper.entity;
 import java.time.LocalDate;
 
 import doldol_server.doldol.common.entity.BaseEntity;
+import doldol_server.doldol.rollingPaper.dto.request.PaperType;
+import doldol_server.doldol.user.entity.Role;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -43,12 +47,17 @@ public class Paper extends BaseEntity {
 	@Column(name = "is_deleted")
 	private boolean isDeleted = false;
 
+	@Enumerated(value = EnumType.STRING)
+	@Column(name = "type")
+	private PaperType paperType;
+
 	@Builder
-	public Paper(String name, String description, LocalDate openDate, String invitationCode) {
+	public Paper(String name, String description, LocalDate openDate, String invitationCode, PaperType paperType) {
 		this.name = name;
 		this.description = description;
 		this.openDate = openDate;
 		this.invitationCode = invitationCode;
+		this.paperType = paperType;
 	}
 
 	public void addParticipant() {

--- a/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustom.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustom.java
@@ -35,4 +35,12 @@ public interface MessageRepositoryCustom {
 		Long paperId,
 		Long userId
 	);
+
+	List<MessageResponse> getIndividualMessages(
+		Long paperId,
+		Long userId,
+		CursorPageRequest request
+	);
+
+	Long getIndividualMessagesCount(Long paperId);
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustomImpl.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustomImpl.java
@@ -161,4 +161,50 @@ public class MessageRepositoryCustomImpl implements MessageRepositoryCustom {
 			)
 			.fetchOne();
 	}
+
+	@Override
+	public List<MessageResponse> getIndividualMessages(Long paperId, Long userId, CursorPageRequest request) {
+		QMessage message = QMessage.message;
+		QUser user = QUser.user;
+
+		BooleanExpression cursorCondition = null;
+		if (request.cursorId() != null) {
+			cursorCondition = message.id.loe(request.cursorId());
+		}
+
+		List<Message> messages = queryFactory
+			.selectFrom(message)
+			.where(
+				message.paper.id.eq(paperId),
+				message.isDeleted.eq(false),
+				cursorCondition
+			)
+			.orderBy(message.id.desc())
+			.limit(request.size() + 1L)
+			.fetch();
+
+		String toName = queryFactory
+			.select(user.name)
+			.from(user)
+			.where(user.id.eq(userId))
+			.fetchOne();
+
+		return messages.stream()
+			.map(msg -> MessageResponse.of(msg, msg.getName(), toName, MessageType.RECEIVE))
+			.toList();
+	}
+
+	@Override
+	public Long getIndividualMessagesCount(Long paperId) {
+		QMessage message = QMessage.message;
+
+		return queryFactory
+			.select(message.count())
+			.from(message)
+			.where(
+				message.paper.id.eq(paperId),
+				message.isDeleted.eq(false)
+			)
+			.fetchOne();
+	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/PaperRepositoryCustom.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/PaperRepositoryCustom.java
@@ -14,4 +14,5 @@ public interface PaperRepositoryCustom {
 		SortDirection sortDirection
 	);
 
+	PaperResponse findPaperWithUserByInvitationCode(String invitationCode);
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/PaperService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/PaperService.java
@@ -50,8 +50,12 @@ public class PaperService {
 	}
 
 	public PaperResponse getInvitation(String invitationCode) {
-		Paper paper = getByInvitationCode(invitationCode);
-		return PaperResponse.of(paper);
+		PaperResponse paperResponse = paperRepository.findPaperWithUserByInvitationCode(invitationCode);
+
+		if (paperResponse == null) {
+			throw new CustomException(PAPER_NOT_FOUND);
+		}
+		return paperResponse;
 	}
 
 	@Transactional

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/PaperService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/PaperService.java
@@ -39,7 +39,9 @@ public class PaperService {
 			.description(request.description())
 			.openDate(request.openDate())
 			.invitationCode(invitationCode)
+			.paperType(request.paperType())
 			.build();
+
 		paperRepository.save(paper);
 
 		participantService.addUser(userId, paper, true);

--- a/src/test/java/doldol_server/doldol/rollingPaper/controller/MessageControllerTest.java
+++ b/src/test/java/doldol_server/doldol/rollingPaper/controller/MessageControllerTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -21,6 +20,7 @@ import doldol_server.doldol.common.exception.CustomException;
 import doldol_server.doldol.common.exception.errorCode.MessageErrorCode;
 import doldol_server.doldol.rollingPaper.dto.request.CreateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.request.DeleteMessageRequest;
+import doldol_server.doldol.rollingPaper.dto.request.PaperType;
 import doldol_server.doldol.rollingPaper.dto.request.UpdateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.response.MessageListResponse;
 import doldol_server.doldol.rollingPaper.dto.response.MessageResponse;
@@ -211,7 +211,7 @@ class MessageControllerTest extends ControllerTest {
 		CreateMessageRequest request = new CreateMessageRequest(
 			1L, 2L, "안녕하세요!", "김철수", "Arial", "#FFFFFF"
 		);
-		doNothing().when(messageService).createMessage(any(CreateMessageRequest.class), anyLong());
+		doNothing().when(messageService).createMessage(any(CreateMessageRequest.class), PaperType.GROUP, anyLong());
 
 		// when & then
 		mockMvc.perform(post("/messages")
@@ -221,7 +221,7 @@ class MessageControllerTest extends ControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.status").value(204));
 
-		verify(messageService).createMessage(any(CreateMessageRequest.class), eq(1L));
+		verify(messageService).createMessage(any(CreateMessageRequest.class), PaperType.GROUP, eq(1L));
 	}
 
 	@Test
@@ -238,7 +238,7 @@ class MessageControllerTest extends ControllerTest {
 				.content(asJsonString(request)))
 			.andExpect(status().isBadRequest());
 
-		verify(messageService, never()).createMessage(any(CreateMessageRequest.class), anyLong());
+		verify(messageService, never()).createMessage(any(CreateMessageRequest.class), PaperType.GROUP, anyLong());
 	}
 
 	@Test

--- a/src/test/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustomImplTest.java
+++ b/src/test/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustomImplTest.java
@@ -501,4 +501,176 @@ class MessageRepositoryCustomImplTest extends RepositoryTest {
 		// then
 		assertThat(result).isNotNull();
 	}
+	@Test
+	@DisplayName("전체 메시지 조회 - 성공")
+	void getAllMessages_Success() {
+		// given
+		Message message1 = Message.builder()
+			.name("김철수")
+			.content("첫 번째 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(message1);
+
+		Message message2 = Message.builder()
+			.name("익명")
+			.content("두 번째 메시지")
+			.fontStyle("Georgia")
+			.backgroundColor("#F0F0F0")
+			.from(null)
+			.to(null)
+			.paper(paper)
+			.build();
+		messageRepository.save(message2);
+
+		Message message3 = Message.builder()
+			.name("박민수")
+			.content("세 번째 메시지")
+			.fontStyle("Times")
+			.backgroundColor("#E0E0E0")
+			.from(otherUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(message3);
+
+		CursorPageRequest request = new CursorPageRequest(null, 10);
+
+		// when
+		List<MessageResponse> result = messageRepositoryCustom.getIndividualMessages(paper.getId(), toUser.getId(), request);
+
+		// then
+		assertThat(result).hasSize(3);
+		assertThat(result.get(0).messageType()).isEqualTo(MessageType.RECEIVE);
+		assertThat(result.get(1).messageType()).isEqualTo(MessageType.RECEIVE);
+		assertThat(result.get(2).messageType()).isEqualTo(MessageType.RECEIVE);
+
+		assertThat(result.get(0).toName()).isEqualTo("이영희");
+		assertThat(result.get(1).toName()).isEqualTo("이영희");
+		assertThat(result.get(2).toName()).isEqualTo("이영희");
+
+		assertThat(result.get(0).messageId()).isGreaterThan(result.get(1).messageId());
+		assertThat(result.get(1).messageId()).isGreaterThan(result.get(2).messageId());
+	}
+
+	@Test
+	@DisplayName("전체 메시지 조회 - 삭제된 메시지 제외")
+	void getAllMessages_ExcludeDeletedMessages() {
+		// given
+		Message normalMessage = Message.builder()
+			.name("김철수")
+			.content("정상 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(normalMessage);
+
+		Message deletedMessage = Message.builder()
+			.name("박민수")
+			.content("삭제된 메시지")
+			.fontStyle("Georgia")
+			.backgroundColor("#F0F0F0")
+			.from(otherUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		deletedMessage.updateDeleteStatus();
+		messageRepository.save(deletedMessage);
+
+		CursorPageRequest request = new CursorPageRequest(null, 10);
+
+		// when
+		List<MessageResponse> result = messageRepositoryCustom.getIndividualMessages(paper.getId(), toUser.getId(), request);
+
+		// then
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).content()).isEqualTo("정상 메시지");
+		assertThat(result.get(0).isDeleted()).isFalse();
+	}
+
+
+	@Test
+	@DisplayName("전체 메시지 수 조회 - 성공")
+	void getAllMessagesCount_Success() {
+		// given
+		Message message1 = Message.builder()
+			.name("김철수")
+			.content("첫 번째 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(message1);
+
+		Message message2 = Message.builder()
+			.name("익명")
+			.content("두 번째 메시지")
+			.fontStyle("Georgia")
+			.backgroundColor("#F0F0F0")
+			.from(null)
+			.to(null)
+			.paper(paper)
+			.build();
+		messageRepository.save(message2);
+
+		Message message3 = Message.builder()
+			.name("박민수")
+			.content("세 번째 메시지")
+			.fontStyle("Times")
+			.backgroundColor("#E0E0E0")
+			.from(otherUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(message3);
+
+		// when
+		Long count = messageRepositoryCustom.getIndividualMessagesCount(paper.getId());
+
+		// then
+		assertThat(count).isEqualTo(3L);
+	}
+
+	@Test
+	@DisplayName("전체 메시지 수 조회 - 삭제된 메시지 제외")
+	void getAllMessagesCount_ExcludeDeletedMessages() {
+		// given
+		Message normalMessage = Message.builder()
+			.name("김철수")
+			.content("정상 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(normalMessage);
+
+		Message deletedMessage = Message.builder()
+			.name("박민수")
+			.content("삭제된 메시지")
+			.fontStyle("Georgia")
+			.backgroundColor("#F0F0F0")
+			.from(otherUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		deletedMessage.updateDeleteStatus();
+		messageRepository.save(deletedMessage);
+
+		// when
+		Long count = messageRepositoryCustom.getIndividualMessagesCount(paper.getId());
+
+		// then
+		assertThat(count).isEqualTo(1L);
+	}
 }


### PR DESCRIPTION
## 📄 PR 내용

- 개인용 롤링페이퍼 작성 및 해당 롤링페이퍼 링크를 받은 사용자는 인증/인가가 필요없는 기능입니다.

## 📝 수정 상세 내용 

- 롤링페이퍼 생성 시 Paper Type 필드를 추가로 받습니다.
- 기존과 똑같이 공유 링크가 만들어지고 초대 코드를 바탕으로 똑같이 db에서 조회하는데 응답값에 paper type과 receiver id가 추가로 세팅됩니다.
- receiver id를 받는 이유는 기존에 메세지를 작성할때 누구한테 작성 할 지 명시했는데 이를 최대한 기존 로직을 변경하지 않기위해 응답값에 추가했습니다.

## ✅ 체크리스트

- [ ] 기존 롤링페이퍼를 개인용/공용으로 분리
- [ ] 메세지 작성 로직 변경

## 📍 레퍼런스

- X