### PR TITLE
[FEAT] 사용자 롤링페이퍼 주문

### DIFF
--- a/src/main/java/doldol_server/doldol/common/config/SecurityConfig.java
+++ b/src/main/java/doldol_server/doldol/common/config/SecurityConfig.java
@@ -50,7 +50,8 @@ public class SecurityConfig {
 		"/swagger-resources/**",
 		"/webjars/**",
 		"/actuator/**",
-		"/papers/invite"
+		"/papers/invite",
+		"/messages/individual"
 	};
 
 	private static final String[] BLACKLIST = {

--- a/src/main/java/doldol_server/doldol/order/controller/OrderController.java
+++ b/src/main/java/doldol_server/doldol/order/controller/OrderController.java
@@ -13,6 +13,7 @@ import doldol_server.doldol.order.service.OrderService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "주문 ")
@@ -29,7 +30,7 @@ public class OrderController {
 		description = "주문",
 		security = {@SecurityRequirement(name = "jwt")})
 	public ApiResponse<Void> order(
-		@RequestBody OrderRequest orderRequest,
+		@RequestBody @Valid OrderRequest orderRequest,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		orderService.order(orderRequest.paperId(), orderRequest.messageIds(), orderRequest.count(),
 			userDetails.getUserId());

--- a/src/main/java/doldol_server/doldol/order/controller/OrderController.java
+++ b/src/main/java/doldol_server/doldol/order/controller/OrderController.java
@@ -1,0 +1,38 @@
+package doldol_server.doldol.order.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import doldol_server.doldol.auth.dto.CustomUserDetails;
+import doldol_server.doldol.common.response.ApiResponse;
+import doldol_server.doldol.order.dto.request.OrderRequest;
+import doldol_server.doldol.order.service.OrderService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "주문 ")
+@RestController
+@RequestMapping("/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+	private final OrderService orderService;
+
+	@PostMapping()
+	@Operation(
+		summary = "주문 API",
+		description = "주문",
+		security = {@SecurityRequirement(name = "jwt")})
+	public ApiResponse<Void> order(
+		@RequestBody OrderRequest orderRequest,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		orderService.order(orderRequest.paperId(), orderRequest.messageIds(), orderRequest.count(),
+			userDetails.getUserId());
+		return ApiResponse.noContent();
+	}
+}

--- a/src/main/java/doldol_server/doldol/order/dto/request/OrderRequest.java
+++ b/src/main/java/doldol_server/doldol/order/dto/request/OrderRequest.java
@@ -1,0 +1,26 @@
+package doldol_server.doldol.order.dto.request;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(name = "OrderRequest: 주문 요청 Dto")
+public record OrderRequest(
+	@NotNull(message = "롤링페이퍼 ID는 필수입니다.")
+	@Schema(description = "롤링페이퍼 ID", example = "1")
+	Long paperId,
+
+	@NotNull(message = "메시지 ID 목록은 필수입니다.")
+	@Size(min = 1, max = 10, message = "메시지는 1개 이상 10개 이하여야 합니다.")
+	@Schema(description = "메시지 ID 목록", example = "[1, 2, 3]")
+	List<Long> messageIds,
+
+	@NotNull(message = "주문 갯수는 필수입니다.")
+	@Min(value = 1, message = "갯수는 1 이상이어야 합니다.")
+	@Schema(description = "주문 갯수", example = "1")
+	Long count
+) {
+}

--- a/src/main/java/doldol_server/doldol/order/entity/Order.java
+++ b/src/main/java/doldol_server/doldol/order/entity/Order.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +21,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Table(name = "orders")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order extends BaseEntity {
 

--- a/src/main/java/doldol_server/doldol/order/entity/Order.java
+++ b/src/main/java/doldol_server/doldol/order/entity/Order.java
@@ -1,0 +1,61 @@
+package doldol_server.doldol.order.entity;
+
+import doldol_server.doldol.common.entity.BaseEntity;
+import doldol_server.doldol.rollingPaper.entity.Paper;
+import doldol_server.doldol.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "order_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "paper_id")
+	private Paper paper;
+
+	@Column(name = "message_ids", nullable = false)
+	private String messageIds;
+
+	@Column(name = "count")
+	private Long count;
+
+	@Column(name = "is_deleted")
+	private boolean isDeleted = false;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status")
+	private OrderStatus orderStatus = OrderStatus.READY;
+
+	@Builder
+	public Order(String messageIds, Long count, boolean isDeleted, OrderStatus orderStatus, Paper paper, User user) {
+		this.messageIds = messageIds;
+		this.count = count;
+		this.isDeleted = isDeleted;
+		this.orderStatus = orderStatus;
+		this.paper = paper;
+		this.user = user;
+	}
+}

--- a/src/main/java/doldol_server/doldol/order/entity/Order.java
+++ b/src/main/java/doldol_server/doldol/order/entity/Order.java
@@ -1,8 +1,12 @@
 package doldol_server.doldol.order.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import doldol_server.doldol.common.entity.BaseEntity;
 import doldol_server.doldol.rollingPaper.entity.Paper;
 import doldol_server.doldol.user.entity.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -13,6 +17,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -38,8 +43,8 @@ public class Order extends BaseEntity {
 	@JoinColumn(name = "paper_id")
 	private Paper paper;
 
-	@Column(name = "message_ids", nullable = false)
-	private String messageIds;
+	@OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<OrderMessage> orderMessages = new ArrayList<>();
 
 	@Column(name = "count")
 	private Long count;
@@ -52,12 +57,17 @@ public class Order extends BaseEntity {
 	private OrderStatus orderStatus = OrderStatus.READY;
 
 	@Builder
-	public Order(String messageIds, Long count, boolean isDeleted, OrderStatus orderStatus, Paper paper, User user) {
-		this.messageIds = messageIds;
+	public Order(List<OrderMessage> orderMessages, Long count, boolean isDeleted,
+		OrderStatus orderStatus, Paper paper, User user) {
+		this.orderMessages = orderMessages != null ? orderMessages : new ArrayList<>();
 		this.count = count;
 		this.isDeleted = isDeleted;
 		this.orderStatus = orderStatus;
 		this.paper = paper;
 		this.user = user;
+	}
+
+	public void addOrderMessage(OrderMessage orderMessage) {
+		this.orderMessages.add(orderMessage);
 	}
 }

--- a/src/main/java/doldol_server/doldol/order/entity/OrderMessage.java
+++ b/src/main/java/doldol_server/doldol/order/entity/OrderMessage.java
@@ -1,0 +1,43 @@
+package doldol_server.doldol.order.entity;
+
+import doldol_server.doldol.common.entity.BaseEntity;
+import doldol_server.doldol.rollingPaper.entity.Message;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "order_messages")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderMessage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_message_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id")
+    private Message message;
+
+    @Builder
+    public OrderMessage(Order order, Message message) {
+        this.order = order;
+        this.message = message;
+    }
+}

--- a/src/main/java/doldol_server/doldol/order/entity/OrderStatus.java
+++ b/src/main/java/doldol_server/doldol/order/entity/OrderStatus.java
@@ -1,0 +1,15 @@
+package doldol_server.doldol.order.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderStatus {
+	READY("준비중"),
+	SHIPPING("배송중"),
+	DONE("배송 완료")
+	;
+
+	private final String displayName;
+}

--- a/src/main/java/doldol_server/doldol/order/repository/OrderMessageRepository.java
+++ b/src/main/java/doldol_server/doldol/order/repository/OrderMessageRepository.java
@@ -1,0 +1,8 @@
+package doldol_server.doldol.order.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import doldol_server.doldol.order.entity.OrderMessage;
+
+public interface OrderMessageRepository extends JpaRepository<OrderMessage, Long> {
+}

--- a/src/main/java/doldol_server/doldol/order/repository/OrderRepository.java
+++ b/src/main/java/doldol_server/doldol/order/repository/OrderRepository.java
@@ -1,0 +1,8 @@
+package doldol_server.doldol.order.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import doldol_server.doldol.order.entity.Order;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/doldol_server/doldol/order/service/OrderService.java
+++ b/src/main/java/doldol_server/doldol/order/service/OrderService.java
@@ -1,16 +1,19 @@
 package doldol_server.doldol.order.service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import doldol_server.doldol.common.exception.CustomException;
+import doldol_server.doldol.common.exception.errorCode.MessageErrorCode;
 import doldol_server.doldol.common.exception.errorCode.PaperErrorCode;
 import doldol_server.doldol.order.entity.Order;
+import doldol_server.doldol.order.entity.OrderMessage;
 import doldol_server.doldol.order.repository.OrderRepository;
+import doldol_server.doldol.rollingPaper.entity.Message;
 import doldol_server.doldol.rollingPaper.entity.Paper;
+import doldol_server.doldol.rollingPaper.repository.MessageRepository;
 import doldol_server.doldol.rollingPaper.repository.PaperRepository;
 import doldol_server.doldol.user.entity.User;
 import doldol_server.doldol.user.service.UserService;
@@ -23,27 +26,32 @@ public class OrderService {
 
 	private final UserService userService;
 	private final PaperRepository paperRepository;
+	private final MessageRepository messageRepository;
 	private final OrderRepository orderRepository;
 
 	@Transactional
-	public void order(Long paperId,
-		List<Long> messageIds,
-		Long count, Long userId) {
+	public void order(Long paperId, List<Long> messageIds, Long count, Long userId) {
 		User user = userService.getById(userId);
 		Paper paper = paperRepository.findById(paperId)
 			.orElseThrow(() -> new CustomException(PaperErrorCode.PAPER_NOT_FOUND));
 
-		String messageIdsString = messageIds.stream()
-			.map(String::valueOf)
-			.collect(Collectors.joining(","));
-
-
 		Order order = Order.builder()
 			.paper(paper)
 			.user(user)
-			.messageIds(messageIdsString)
 			.count(count)
 			.build();
+
+		messageIds.forEach(messageId -> {
+			Message message = messageRepository.findById(messageId)
+				.orElseThrow(() -> new CustomException(MessageErrorCode.MESSAGE_NOT_FOUND));
+
+			OrderMessage orderMessage = OrderMessage.builder()
+				.order(order)
+				.message(message)
+				.build();
+
+			order.addOrderMessage(orderMessage);
+		});
 
 		orderRepository.save(order);
 	}

--- a/src/main/java/doldol_server/doldol/order/service/OrderService.java
+++ b/src/main/java/doldol_server/doldol/order/service/OrderService.java
@@ -1,0 +1,50 @@
+package doldol_server.doldol.order.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import doldol_server.doldol.common.exception.CustomException;
+import doldol_server.doldol.common.exception.errorCode.PaperErrorCode;
+import doldol_server.doldol.order.entity.Order;
+import doldol_server.doldol.order.repository.OrderRepository;
+import doldol_server.doldol.rollingPaper.entity.Paper;
+import doldol_server.doldol.rollingPaper.repository.PaperRepository;
+import doldol_server.doldol.user.entity.User;
+import doldol_server.doldol.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+
+	private final UserService userService;
+	private final PaperRepository paperRepository;
+	private final OrderRepository orderRepository;
+
+	@Transactional
+	public void order(Long paperId,
+		List<Long> messageIds,
+		Long count, Long userId) {
+		User user = userService.getById(userId);
+		Paper paper = paperRepository.findById(paperId)
+			.orElseThrow(() -> new CustomException(PaperErrorCode.PAPER_NOT_FOUND));
+
+		String messageIdsString = messageIds.stream()
+			.map(String::valueOf)
+			.collect(Collectors.joining(","));
+
+
+		Order order = Order.builder()
+			.paper(paper)
+			.user(user)
+			.messageIds(messageIdsString)
+			.count(count)
+			.build();
+
+		orderRepository.save(order);
+	}
+}

--- a/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
@@ -17,7 +17,7 @@ import doldol_server.doldol.common.request.CursorPageRequest;
 import doldol_server.doldol.common.response.ApiResponse;
 import doldol_server.doldol.rollingPaper.dto.request.CreateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.request.DeleteMessageRequest;
-import doldol_server.doldol.rollingPaper.dto.request.PaperType;
+import doldol_server.doldol.rollingPaper.entity.PaperType;
 import doldol_server.doldol.rollingPaper.dto.request.UpdateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.response.MessageListResponse;
 import doldol_server.doldol.rollingPaper.dto.response.MessageResponse;

--- a/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
@@ -1,7 +1,5 @@
 package doldol_server.doldol.rollingPaper.controller;
 
-import java.time.LocalDate;
-
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;

--- a/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
@@ -19,6 +19,7 @@ import doldol_server.doldol.common.request.CursorPageRequest;
 import doldol_server.doldol.common.response.ApiResponse;
 import doldol_server.doldol.rollingPaper.dto.request.CreateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.request.DeleteMessageRequest;
+import doldol_server.doldol.rollingPaper.dto.request.PaperType;
 import doldol_server.doldol.rollingPaper.dto.request.UpdateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.response.MessageListResponse;
 import doldol_server.doldol.rollingPaper.dto.response.MessageResponse;
@@ -67,15 +68,21 @@ public class MessageController {
 		return ApiResponse.ok(messages);
 	}
 
-	@PostMapping
+	@PostMapping("/{paperType}")
 	@Operation(
 		summary = "메세지 작성 API",
 		description = "메세지 작성",
 		security = {@SecurityRequirement(name = "jwt")})
 	public ApiResponse<Void> createMessage(
+		@PathVariable("paperType") String paperTypeStr,
 		@RequestBody @Valid CreateMessageRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
-		messageService.createMessage(request, userDetails.getUserId());
+		PaperType paperType = PaperType.valueOf(paperTypeStr.toUpperCase());
+
+		Long userId = (paperType == PaperType.GROUP && userDetails != null)
+			? userDetails.getUserId()
+			: null;
+		messageService.createMessage(request, paperType, userId);
 		return ApiResponse.noContent();
 	}
 

--- a/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/controller/MessageController.java
@@ -69,8 +69,7 @@ public class MessageController {
 	@PostMapping("/{paperType}")
 	@Operation(
 		summary = "메세지 작성 API",
-		description = "메세지 작성",
-		security = {@SecurityRequirement(name = "jwt")})
+		description = "메세지 작성")
 	public ApiResponse<Void> createMessage(
 		@PathVariable("paperType") String paperTypeStr,
 		@RequestBody @Valid CreateMessageRequest request,

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/request/PaperRequest.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/request/PaperRequest.java
@@ -15,9 +15,12 @@ public record PaperRequest(
 	@Schema(description = "단체 설명", example = "KB 16회차 짱짱맨 영원하라.")
 	String description,
 
-	@NotNull(message = "메세지 공개 날짜는 필수입니다.")
 	@Schema(description = "메세지 공개 날짜", example = "2025-06-26")
 	@FutureOrPresent(message = "메세지 공개 날짜는 과거일 수 없습니다.")
-	LocalDate openDate
+	LocalDate openDate,
+
+	@NotNull(message = "롤링페이퍼 타입은 필수입니다.")
+	@Schema(description = "롤링페이퍼 타입", example = "GROUP")
+	PaperType paperType
 ) {
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/request/PaperRequest.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/request/PaperRequest.java
@@ -2,6 +2,7 @@ package doldol_server.doldol.rollingPaper.dto.request;
 
 import java.time.LocalDate;
 
+import doldol_server.doldol.rollingPaper.entity.PaperType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/request/PaperType.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/request/PaperType.java
@@ -1,0 +1,15 @@
+package doldol_server.doldol.rollingPaper.dto.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaperType {
+
+	GROUP("그룹용"),
+	INDIVIDUAL("개인용")
+	;
+
+	private final String displayName;
+}

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/response/PaperResponse.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/response/PaperResponse.java
@@ -31,7 +31,10 @@ public record PaperResponse(
 	LocalDate openDate,
 
 	@Schema(description = "롤링페이퍼 타입", example = "GROUP")
-	PaperType paperType
+	PaperType paperType,
+
+	@Schema(description = "롤링페이퍼 생성자 id", example = "1")
+	Long receiverId
 ) {
 	public static PaperResponse of(Paper paper) {
 		return PaperResponse.builder()

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/response/PaperResponse.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/response/PaperResponse.java
@@ -1,9 +1,8 @@
 package doldol_server.doldol.rollingPaper.dto.response;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
-import doldol_server.doldol.rollingPaper.dto.request.PaperType;
+import doldol_server.doldol.rollingPaper.entity.PaperType;
 import doldol_server.doldol.rollingPaper.entity.Paper;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;

--- a/src/main/java/doldol_server/doldol/rollingPaper/dto/response/PaperResponse.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/dto/response/PaperResponse.java
@@ -3,6 +3,7 @@ package doldol_server.doldol.rollingPaper.dto.response;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import doldol_server.doldol.rollingPaper.dto.request.PaperType;
 import doldol_server.doldol.rollingPaper.entity.Paper;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -27,7 +28,10 @@ public record PaperResponse(
 	int messageCount,
 
 	@Schema(description = "메세지 공개 날짜", example = "2025-06-26")
-	LocalDate openDate
+	LocalDate openDate,
+
+	@Schema(description = "롤링페이퍼 타입", example = "GROUP")
+	PaperType paperType
 ) {
 	public static PaperResponse of(Paper paper) {
 		return PaperResponse.builder()
@@ -37,6 +41,7 @@ public record PaperResponse(
 			.participantsCount(paper.getParticipantsCount())
 			.messageCount(paper.getMessageCount())
 			.openDate(paper.getOpenDate())
+			.paperType(paper.getPaperType())
 			.build();
 	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/entity/Paper.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/entity/Paper.java
@@ -32,7 +32,7 @@ public class Paper extends BaseEntity {
 	@Column(name = "description")
 	private String description;
 
-	@Column(name = "open_date", nullable = false)
+	@Column(name = "open_date")
 	private LocalDate openDate;
 
 	@Column(name = "invitation_code", nullable = false)

--- a/src/main/java/doldol_server/doldol/rollingPaper/entity/Paper.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/entity/Paper.java
@@ -3,8 +3,12 @@ package doldol_server.doldol.rollingPaper.entity;
 import java.time.LocalDate;
 
 import doldol_server.doldol.common.entity.BaseEntity;
+import doldol_server.doldol.rollingPaper.dto.request.PaperType;
+import doldol_server.doldol.user.entity.Role;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -43,12 +47,17 @@ public class Paper extends BaseEntity {
 	@Column(name = "is_deleted")
 	private boolean isDeleted = false;
 
+	@Enumerated(value = EnumType.STRING)
+	@Column(name = "type")
+	private PaperType paperType;
+
 	@Builder
-	public Paper(String name, String description, LocalDate openDate, String invitationCode) {
+	public Paper(String name, String description, LocalDate openDate, String invitationCode, PaperType paperType) {
 		this.name = name;
 		this.description = description;
 		this.openDate = openDate;
 		this.invitationCode = invitationCode;
+		this.paperType = paperType;
 	}
 
 	public void addParticipant() {

--- a/src/main/java/doldol_server/doldol/rollingPaper/entity/Paper.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/entity/Paper.java
@@ -3,8 +3,6 @@ package doldol_server.doldol.rollingPaper.entity;
 import java.time.LocalDate;
 
 import doldol_server.doldol.common.entity.BaseEntity;
-import doldol_server.doldol.rollingPaper.dto.request.PaperType;
-import doldol_server.doldol.user.entity.Role;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/doldol_server/doldol/rollingPaper/entity/PaperType.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/entity/PaperType.java
@@ -1,4 +1,4 @@
-package doldol_server.doldol.rollingPaper.dto.request;
+package doldol_server.doldol.rollingPaper.entity;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustom.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustom.java
@@ -35,4 +35,12 @@ public interface MessageRepositoryCustom {
 		Long paperId,
 		Long userId
 	);
+
+	List<MessageResponse> getIndividualMessages(
+		Long paperId,
+		Long userId,
+		CursorPageRequest request
+	);
+
+	Long getIndividualMessagesCount(Long paperId);
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustomImpl.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustomImpl.java
@@ -161,4 +161,50 @@ public class MessageRepositoryCustomImpl implements MessageRepositoryCustom {
 			)
 			.fetchOne();
 	}
+
+	@Override
+	public List<MessageResponse> getIndividualMessages(Long paperId, Long userId, CursorPageRequest request) {
+		QMessage message = QMessage.message;
+		QUser user = QUser.user;
+
+		BooleanExpression cursorCondition = null;
+		if (request.cursorId() != null) {
+			cursorCondition = message.id.loe(request.cursorId());
+		}
+
+		List<Message> messages = queryFactory
+			.selectFrom(message)
+			.where(
+				message.paper.id.eq(paperId),
+				message.isDeleted.eq(false),
+				cursorCondition
+			)
+			.orderBy(message.id.desc())
+			.limit(request.size() + 1L)
+			.fetch();
+
+		String toName = queryFactory
+			.select(user.name)
+			.from(user)
+			.where(user.id.eq(userId))
+			.fetchOne();
+
+		return messages.stream()
+			.map(msg -> MessageResponse.of(msg, msg.getName(), toName, MessageType.RECEIVE))
+			.toList();
+	}
+
+	@Override
+	public Long getIndividualMessagesCount(Long paperId) {
+		QMessage message = QMessage.message;
+
+		return queryFactory
+			.select(message.count())
+			.from(message)
+			.where(
+				message.paper.id.eq(paperId),
+				message.isDeleted.eq(false)
+			)
+			.fetchOne();
+	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/PaperRepositoryCustom.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/repository/custom/PaperRepositoryCustom.java
@@ -14,4 +14,5 @@ public interface PaperRepositoryCustom {
 		SortDirection sortDirection
 	);
 
+	PaperResponse findPaperWithUserByInvitationCode(String invitationCode);
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/MessageService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/MessageService.java
@@ -14,7 +14,7 @@ import doldol_server.doldol.common.exception.errorCode.PaperErrorCode;
 import doldol_server.doldol.common.request.CursorPageRequest;
 import doldol_server.doldol.rollingPaper.dto.request.CreateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.request.DeleteMessageRequest;
-import doldol_server.doldol.rollingPaper.dto.request.PaperType;
+import doldol_server.doldol.rollingPaper.entity.PaperType;
 import doldol_server.doldol.rollingPaper.dto.request.UpdateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.response.MessageListResponse;
 import doldol_server.doldol.rollingPaper.dto.response.MessageResponse;

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/PaperService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/PaperService.java
@@ -50,8 +50,12 @@ public class PaperService {
 	}
 
 	public PaperResponse getInvitation(String invitationCode) {
-		Paper paper = getByInvitationCode(invitationCode);
-		return PaperResponse.of(paper);
+		PaperResponse paperResponse = paperRepository.findPaperWithUserByInvitationCode(invitationCode);
+
+		if (paperResponse == null) {
+			throw new CustomException(PAPER_NOT_FOUND);
+		}
+		return paperResponse;
 	}
 
 	@Transactional

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/PaperService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/PaperService.java
@@ -39,7 +39,9 @@ public class PaperService {
 			.description(request.description())
 			.openDate(request.openDate())
 			.invitationCode(invitationCode)
+			.paperType(request.paperType())
 			.build();
+
 		paperRepository.save(paper);
 
 		participantService.addUser(userId, paper, true);

--- a/src/test/java/doldol_server/doldol/order/controller/OrderControllerTest.java
+++ b/src/test/java/doldol_server/doldol/order/controller/OrderControllerTest.java
@@ -1,0 +1,182 @@
+package doldol_server.doldol.order.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import doldol_server.doldol.common.ControllerTest;
+import doldol_server.doldol.common.exception.CustomException;
+import doldol_server.doldol.common.exception.errorCode.PaperErrorCode;
+import doldol_server.doldol.order.dto.request.OrderRequest;
+import doldol_server.doldol.order.service.OrderService;
+
+@WebMvcTest(controllers = OrderController.class)
+class OrderControllerTest extends ControllerTest {
+
+	@MockitoBean
+	private OrderService orderService;
+
+	@Test
+	@DisplayName("주문 생성 - 성공")
+	void order_Success() throws Exception {
+		// given
+		OrderRequest request = new OrderRequest(1L, List.of(1L, 2L, 3L), 5L);
+		doNothing().when(orderService).order(anyLong(), anyList(), anyLong(), anyLong());
+
+		// when & then
+		mockMvc.perform(post("/orders")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request))
+				.with(mockUser(1L)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(204));
+
+		verify(orderService).order(eq(1L), eq(List.of(1L, 2L, 3L)), eq(5L), eq(1L));
+	}
+
+
+	@Test
+	@DisplayName("주문 생성 - messageIds가 null이면 오류 발생")
+	void order_ValidationFail_MessageIdsNull() throws Exception {
+		// given
+		OrderRequest request = new OrderRequest(1L, null, 5L);
+
+		// when & then
+		mockMvc.perform(post("/orders")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request))
+				.with(mockUser(1L)))
+			.andExpect(status().isBadRequest());
+
+		verify(orderService, never()).order(anyLong(), anyList(), anyLong(), anyLong());
+	}
+
+	@Test
+	@DisplayName("주문 생성 - messageIds가 빈 리스트면 오류 발생")
+	void order_ValidationFail_MessageIdsEmpty() throws Exception {
+		// given
+		OrderRequest request = new OrderRequest(1L, List.of(), 5L);
+
+		// when & then
+		mockMvc.perform(post("/orders")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request))
+				.with(mockUser(1L)))
+			.andExpect(status().isBadRequest());
+
+		verify(orderService, never()).order(anyLong(), anyList(), anyLong(), anyLong());
+	}
+
+	@Test
+	@DisplayName("주문 생성 - messageIds가 10개 초과하면 오류 발생")
+	void order_ValidationFail_MessageIdsTooMany() throws Exception {
+		// given
+		List<Long> tooManyMessageIds = List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L);
+		OrderRequest request = new OrderRequest(1L, tooManyMessageIds, 5L);
+
+		// when & then
+		mockMvc.perform(post("/orders")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request))
+				.with(mockUser(1L)))
+			.andExpect(status().isBadRequest());
+
+		verify(orderService, never()).order(anyLong(), anyList(), anyLong(), anyLong());
+	}
+
+	@Test
+	@DisplayName("주문 생성 - count가 null이면 오류 발생")
+	void order_ValidationFail_CountNull() throws Exception {
+		// given
+		OrderRequest request = new OrderRequest(1L, List.of(1L, 2L, 3L), null);
+
+		// when & then
+		mockMvc.perform(post("/orders")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request))
+				.with(mockUser(1L)))
+			.andExpect(status().isBadRequest());
+
+		verify(orderService, never()).order(anyLong(), anyList(), anyLong(), anyLong());
+	}
+
+	@Test
+	@DisplayName("주문 생성 - count가 1보다 작으면 오류 발생")
+	void order_ValidationFail_CountTooSmall() throws Exception {
+		// given
+		OrderRequest request = new OrderRequest(1L, List.of(1L, 2L, 3L), 0L);
+
+		// when & then
+		mockMvc.perform(post("/orders")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request))
+				.with(mockUser(1L)))
+			.andExpect(status().isBadRequest());
+
+		verify(orderService, never()).order(anyLong(), anyList(), anyLong(), anyLong());
+	}
+
+	@Test
+	@DisplayName("주문 생성 - 존재하지 않는 paper로 주문하면 오류 발생")
+	void order_PaperNotFound() throws Exception {
+		// given
+		OrderRequest request = new OrderRequest(999L, List.of(1L, 2L, 3L), 5L);
+		doThrow(new CustomException(PaperErrorCode.PAPER_NOT_FOUND))
+			.when(orderService).order(anyLong(), anyList(), anyLong(), anyLong());
+
+		// when & then
+		mockMvc.perform(post("/orders")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request))
+				.with(mockUser(1L)))
+			.andExpect(status().isNotFound());
+
+		verify(orderService).order(eq(999L), eq(List.of(1L, 2L, 3L)), eq(5L), eq(1L));
+	}
+
+	@Test
+	@DisplayName("주문 생성 - messageIds 최소/최대 경계값 테스트 (1개)")
+	void order_MessageIds_MinBoundary() throws Exception {
+		// given
+		OrderRequest request = new OrderRequest(1L, List.of(1L), 1L);
+		doNothing().when(orderService).order(anyLong(), anyList(), anyLong(), anyLong());
+
+		// when & then
+		mockMvc.perform(post("/orders")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request))
+				.with(mockUser(1L)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(204));
+
+		verify(orderService).order(eq(1L), eq(List.of(1L)), eq(1L), eq(1L));
+	}
+
+	@Test
+	@DisplayName("주문 생성 - messageIds 최소/최대 경계값 테스트 (10개)")
+	void order_MessageIds_MaxBoundary() throws Exception {
+		// given
+		List<Long> maxMessageIds = List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L);
+		OrderRequest request = new OrderRequest(1L, maxMessageIds, 1L);
+		doNothing().when(orderService).order(anyLong(), anyList(), anyLong(), anyLong());
+
+		// when & then
+		mockMvc.perform(post("/orders")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(asJsonString(request))
+				.with(mockUser(1L)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(204));
+
+		verify(orderService).order(eq(1L), eq(maxMessageIds), eq(1L), eq(1L));
+	}
+}

--- a/src/test/java/doldol_server/doldol/order/service/OrderServiceTest.java
+++ b/src/test/java/doldol_server/doldol/order/service/OrderServiceTest.java
@@ -1,0 +1,262 @@
+package doldol_server.doldol.order.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import doldol_server.doldol.common.ServiceTest;
+import doldol_server.doldol.common.exception.CustomException;
+import doldol_server.doldol.common.exception.errorCode.PaperErrorCode;
+import doldol_server.doldol.order.entity.Order;
+import doldol_server.doldol.order.repository.OrderRepository;
+import doldol_server.doldol.rollingPaper.entity.Paper;
+import doldol_server.doldol.rollingPaper.repository.PaperRepository;
+import doldol_server.doldol.user.entity.User;
+import doldol_server.doldol.user.repository.UserRepository;
+
+@DisplayName("Order 서비스 통합 테스트")
+class OrderServiceTest extends ServiceTest {
+
+	@Autowired
+	private OrderService orderService;
+
+	@Autowired
+	private OrderRepository orderRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private PaperRepository paperRepository;
+
+	private User user;
+	private Paper paper;
+	private List<Long> messageIds;
+
+	private User createAndSaveUser(String loginId, String name, String email, String phone, String password) {
+		User user = User.builder()
+			.loginId(loginId)
+			.name(name)
+			.email(email)
+			.phone(phone)
+			.password(password)
+			.build();
+		return userRepository.save(user);
+	}
+
+	private Paper createAndSavePaper(String name, String description, String invitationCode) {
+		Paper paper = Paper.builder()
+			.name(name)
+			.description(description)
+			.openDate(LocalDate.now().plusDays(7))
+			.invitationCode(invitationCode)
+			.build();
+		return paperRepository.save(paper);
+	}
+
+	@BeforeEach
+	void setUp() {
+		user = createAndSaveUser("testuser", "김철수", "test@example.com", "01012345678", "password123");
+		paper = createAndSavePaper("테스트 페이퍼", "테스트용 롤링페이퍼", "TEST123");
+		messageIds = List.of(1L, 2L, 3L);
+	}
+
+	@Test
+	@DisplayName("주문 생성 - 성공")
+	void order_Success() {
+		// given
+		Long count = 5L;
+
+		// when
+		orderService.order(paper.getId(), messageIds, count, user.getId());
+
+		// then
+		List<Order> orders = orderRepository.findAll();
+		assertThat(orders).hasSize(1);
+
+		Order savedOrder = orders.get(0);
+		assertThat(savedOrder.getPaper().getId()).isEqualTo(paper.getId());
+		assertThat(savedOrder.getUser().getId()).isEqualTo(user.getId());
+		assertThat(savedOrder.getMessageIds()).isEqualTo("1,2,3");
+		assertThat(savedOrder.getCount()).isEqualTo(count);
+		assertThat(savedOrder.getCreatedAt()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("주문 생성 - 단일 messageId로 성공")
+	void order_SingleMessageId_Success() {
+		// given
+		List<Long> singleMessageId = List.of(42L);
+		Long count = 1L;
+
+		// when
+		orderService.order(paper.getId(), singleMessageId, count, user.getId());
+
+		// then
+		List<Order> orders = orderRepository.findAll();
+		assertThat(orders).hasSize(1);
+
+		Order savedOrder = orders.get(0);
+		assertThat(savedOrder.getMessageIds()).isEqualTo("42");
+		assertThat(savedOrder.getCount()).isEqualTo(count);
+	}
+
+	@Test
+	@DisplayName("주문 생성 - 최대 개수 messageIds로 성공")
+	void order_MaxMessageIds_Success() {
+		// given
+		List<Long> maxMessageIds = List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L);
+		Long count = 10L;
+
+		// when
+		orderService.order(paper.getId(), maxMessageIds, count, user.getId());
+
+		// then
+		List<Order> orders = orderRepository.findAll();
+		assertThat(orders).hasSize(1);
+
+		Order savedOrder = orders.get(0);
+		assertThat(savedOrder.getMessageIds()).isEqualTo("1,2,3,4,5,6,7,8,9,10");
+		assertThat(savedOrder.getCount()).isEqualTo(count);
+	}
+
+	@Test
+	@DisplayName("주문 생성 - 존재하지 않는 Paper ID로 실패")
+	void order_PaperNotFound() {
+		// given
+		Long nonExistentPaperId = 999L;
+		Long count = 5L;
+
+		// when & then
+		assertThatThrownBy(() -> orderService.order(nonExistentPaperId, messageIds, count, user.getId()))
+			.isInstanceOf(CustomException.class)
+			.hasMessage(PaperErrorCode.PAPER_NOT_FOUND.getMessage());
+
+		List<Order> orders = orderRepository.findAll();
+		assertThat(orders).isEmpty();
+	}
+
+	@Test
+	@DisplayName("주문 생성 - 존재하지 않는 User ID로 실패")
+	void order_UserNotFound() {
+		// given
+		Long nonExistentUserId = 999L;
+		Long count = 5L;
+
+		// when & then
+		assertThatThrownBy(() -> orderService.order(paper.getId(), messageIds, count, nonExistentUserId))
+			.isInstanceOf(CustomException.class);
+
+		List<Order> orders = orderRepository.findAll();
+		assertThat(orders).isEmpty();
+	}
+
+	@Test
+	@DisplayName("주문 생성 - 여러 사용자가 동일한 Paper에 주문 성공")
+	void order_MultipleUsers_Success() {
+		// given
+		User anotherUser = createAndSaveUser("another", "이영희", "another@example.com", "01087654321", "password456");
+		Long count1 = 3L;
+		Long count2 = 7L;
+
+		// when
+		orderService.order(paper.getId(), messageIds, count1, user.getId());
+		orderService.order(paper.getId(), List.of(4L, 5L), count2, anotherUser.getId());
+
+		// then
+		List<Order> orders = orderRepository.findAll();
+		assertThat(orders).hasSize(2);
+
+		Order firstOrder = orders.stream()
+			.filter(order -> order.getUser().getId().equals(user.getId()))
+			.findFirst()
+			.orElseThrow();
+		assertThat(firstOrder.getMessageIds()).isEqualTo("1,2,3");
+		assertThat(firstOrder.getCount()).isEqualTo(count1);
+
+		Order secondOrder = orders.stream()
+			.filter(order -> order.getUser().getId().equals(anotherUser.getId()))
+			.findFirst()
+			.orElseThrow();
+		assertThat(secondOrder.getMessageIds()).isEqualTo("4,5");
+		assertThat(secondOrder.getCount()).isEqualTo(count2);
+	}
+
+	@Test
+	@DisplayName("주문 생성 - 동일한 사용자가 동일한 Paper에 여러 번 주문 성공")
+	void order_SameUserMultipleOrders_Success() {
+		// given
+		Long count1 = 2L;
+		Long count2 = 8L;
+
+		// when
+		orderService.order(paper.getId(), List.of(1L, 2L), count1, user.getId());
+		orderService.order(paper.getId(), List.of(3L, 4L, 5L), count2, user.getId());
+
+		// then
+		List<Order> orders = orderRepository.findAll();
+		assertThat(orders).hasSize(2);
+
+		orders.forEach(order -> {
+			assertThat(order.getUser().getId()).isEqualTo(user.getId());
+			assertThat(order.getPaper().getId()).isEqualTo(paper.getId());
+		});
+	}
+
+	@Test
+	@DisplayName("주문 생성 - messageIds가 큰 숫자들로 구성되어도 성공")
+	void order_LargeMessageIds_Success() {
+		// given
+		List<Long> largeMessageIds = List.of(999999L, 888888L, 777777L);
+		Long count = 3L;
+
+		// when
+		orderService.order(paper.getId(), largeMessageIds, count, user.getId());
+
+		// then
+		List<Order> orders = orderRepository.findAll();
+		assertThat(orders).hasSize(1);
+
+		Order savedOrder = orders.get(0);
+		assertThat(savedOrder.getMessageIds()).isEqualTo("999999,888888,777777");
+	}
+
+	@Test
+	@DisplayName("주문 생성 - 트랜잭션 롤백 테스트")
+	void order_TransactionRollback() {
+		// given
+		Long nonExistentUserId = 999L;
+
+		// when & then
+		assertThatThrownBy(() -> orderService.order(paper.getId(), messageIds, 5L, nonExistentUserId))
+			.isInstanceOf(CustomException.class);
+
+		List<Order> orders = orderRepository.findAll();
+		assertThat(orders).isEmpty();
+	}
+
+	@Test
+	@DisplayName("주문 생성 - messageIds 순서 유지 확인")
+	void order_MessageIdsOrder_Preserved() {
+		// given
+		List<Long> orderedMessageIds = List.of(5L, 1L, 9L, 3L, 7L);
+		Long count = 5L;
+
+		// when
+		orderService.order(paper.getId(), orderedMessageIds, count, user.getId());
+
+		// then
+		List<Order> orders = orderRepository.findAll();
+		assertThat(orders).hasSize(1);
+
+		Order savedOrder = orders.get(0);
+		// 입력한 순서대로 저장되는지 확인
+		assertThat(savedOrder.getMessageIds()).isEqualTo("5,1,9,3,7");
+	}
+}

--- a/src/test/java/doldol_server/doldol/rollingPaper/controller/MessageControllerTest.java
+++ b/src/test/java/doldol_server/doldol/rollingPaper/controller/MessageControllerTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -21,6 +20,7 @@ import doldol_server.doldol.common.exception.CustomException;
 import doldol_server.doldol.common.exception.errorCode.MessageErrorCode;
 import doldol_server.doldol.rollingPaper.dto.request.CreateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.request.DeleteMessageRequest;
+import doldol_server.doldol.rollingPaper.dto.request.PaperType;
 import doldol_server.doldol.rollingPaper.dto.request.UpdateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.response.MessageListResponse;
 import doldol_server.doldol.rollingPaper.dto.response.MessageResponse;
@@ -211,7 +211,7 @@ class MessageControllerTest extends ControllerTest {
 		CreateMessageRequest request = new CreateMessageRequest(
 			1L, 2L, "안녕하세요!", "김철수", "Arial", "#FFFFFF"
 		);
-		doNothing().when(messageService).createMessage(any(CreateMessageRequest.class), anyLong());
+		doNothing().when(messageService).createMessage(any(CreateMessageRequest.class), PaperType.GROUP, anyLong());
 
 		// when & then
 		mockMvc.perform(post("/messages")
@@ -221,7 +221,7 @@ class MessageControllerTest extends ControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.status").value(204));
 
-		verify(messageService).createMessage(any(CreateMessageRequest.class), eq(1L));
+		verify(messageService).createMessage(any(CreateMessageRequest.class), PaperType.GROUP, eq(1L));
 	}
 
 	@Test
@@ -238,7 +238,7 @@ class MessageControllerTest extends ControllerTest {
 				.content(asJsonString(request)))
 			.andExpect(status().isBadRequest());
 
-		verify(messageService, never()).createMessage(any(CreateMessageRequest.class), anyLong());
+		verify(messageService, never()).createMessage(any(CreateMessageRequest.class), PaperType.GROUP, anyLong());
 	}
 
 	@Test

--- a/src/test/java/doldol_server/doldol/rollingPaper/controller/MessageControllerTest.java
+++ b/src/test/java/doldol_server/doldol/rollingPaper/controller/MessageControllerTest.java
@@ -20,7 +20,7 @@ import doldol_server.doldol.common.exception.CustomException;
 import doldol_server.doldol.common.exception.errorCode.MessageErrorCode;
 import doldol_server.doldol.rollingPaper.dto.request.CreateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.request.DeleteMessageRequest;
-import doldol_server.doldol.rollingPaper.dto.request.PaperType;
+import doldol_server.doldol.rollingPaper.entity.PaperType;
 import doldol_server.doldol.rollingPaper.dto.request.UpdateMessageRequest;
 import doldol_server.doldol.rollingPaper.dto.response.MessageListResponse;
 import doldol_server.doldol.rollingPaper.dto.response.MessageResponse;

--- a/src/test/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustomImplTest.java
+++ b/src/test/java/doldol_server/doldol/rollingPaper/repository/custom/MessageRepositoryCustomImplTest.java
@@ -501,4 +501,176 @@ class MessageRepositoryCustomImplTest extends RepositoryTest {
 		// then
 		assertThat(result).isNotNull();
 	}
+	@Test
+	@DisplayName("전체 메시지 조회 - 성공")
+	void getAllMessages_Success() {
+		// given
+		Message message1 = Message.builder()
+			.name("김철수")
+			.content("첫 번째 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(message1);
+
+		Message message2 = Message.builder()
+			.name("익명")
+			.content("두 번째 메시지")
+			.fontStyle("Georgia")
+			.backgroundColor("#F0F0F0")
+			.from(null)
+			.to(null)
+			.paper(paper)
+			.build();
+		messageRepository.save(message2);
+
+		Message message3 = Message.builder()
+			.name("박민수")
+			.content("세 번째 메시지")
+			.fontStyle("Times")
+			.backgroundColor("#E0E0E0")
+			.from(otherUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(message3);
+
+		CursorPageRequest request = new CursorPageRequest(null, 10);
+
+		// when
+		List<MessageResponse> result = messageRepositoryCustom.getIndividualMessages(paper.getId(), toUser.getId(), request);
+
+		// then
+		assertThat(result).hasSize(3);
+		assertThat(result.get(0).messageType()).isEqualTo(MessageType.RECEIVE);
+		assertThat(result.get(1).messageType()).isEqualTo(MessageType.RECEIVE);
+		assertThat(result.get(2).messageType()).isEqualTo(MessageType.RECEIVE);
+
+		assertThat(result.get(0).toName()).isEqualTo("이영희");
+		assertThat(result.get(1).toName()).isEqualTo("이영희");
+		assertThat(result.get(2).toName()).isEqualTo("이영희");
+
+		assertThat(result.get(0).messageId()).isGreaterThan(result.get(1).messageId());
+		assertThat(result.get(1).messageId()).isGreaterThan(result.get(2).messageId());
+	}
+
+	@Test
+	@DisplayName("전체 메시지 조회 - 삭제된 메시지 제외")
+	void getAllMessages_ExcludeDeletedMessages() {
+		// given
+		Message normalMessage = Message.builder()
+			.name("김철수")
+			.content("정상 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(normalMessage);
+
+		Message deletedMessage = Message.builder()
+			.name("박민수")
+			.content("삭제된 메시지")
+			.fontStyle("Georgia")
+			.backgroundColor("#F0F0F0")
+			.from(otherUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		deletedMessage.updateDeleteStatus();
+		messageRepository.save(deletedMessage);
+
+		CursorPageRequest request = new CursorPageRequest(null, 10);
+
+		// when
+		List<MessageResponse> result = messageRepositoryCustom.getIndividualMessages(paper.getId(), toUser.getId(), request);
+
+		// then
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).content()).isEqualTo("정상 메시지");
+		assertThat(result.get(0).isDeleted()).isFalse();
+	}
+
+
+	@Test
+	@DisplayName("전체 메시지 수 조회 - 성공")
+	void getAllMessagesCount_Success() {
+		// given
+		Message message1 = Message.builder()
+			.name("김철수")
+			.content("첫 번째 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(message1);
+
+		Message message2 = Message.builder()
+			.name("익명")
+			.content("두 번째 메시지")
+			.fontStyle("Georgia")
+			.backgroundColor("#F0F0F0")
+			.from(null)
+			.to(null)
+			.paper(paper)
+			.build();
+		messageRepository.save(message2);
+
+		Message message3 = Message.builder()
+			.name("박민수")
+			.content("세 번째 메시지")
+			.fontStyle("Times")
+			.backgroundColor("#E0E0E0")
+			.from(otherUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(message3);
+
+		// when
+		Long count = messageRepositoryCustom.getIndividualMessagesCount(paper.getId());
+
+		// then
+		assertThat(count).isEqualTo(3L);
+	}
+
+	@Test
+	@DisplayName("전체 메시지 수 조회 - 삭제된 메시지 제외")
+	void getAllMessagesCount_ExcludeDeletedMessages() {
+		// given
+		Message normalMessage = Message.builder()
+			.name("김철수")
+			.content("정상 메시지")
+			.fontStyle("Arial")
+			.backgroundColor("#FFFFFF")
+			.from(fromUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		messageRepository.save(normalMessage);
+
+		Message deletedMessage = Message.builder()
+			.name("박민수")
+			.content("삭제된 메시지")
+			.fontStyle("Georgia")
+			.backgroundColor("#F0F0F0")
+			.from(otherUser)
+			.to(toUser)
+			.paper(paper)
+			.build();
+		deletedMessage.updateDeleteStatus();
+		messageRepository.save(deletedMessage);
+
+		// when
+		Long count = messageRepositoryCustom.getIndividualMessagesCount(paper.getId());
+
+		// then
+		assertThat(count).isEqualTo(1L);
+	}
 }


### PR DESCRIPTION
## 📄 PR 내용

- 메세지와 주문 관계가 다대다로 판단이 들어서, 일대다와 다대일로 구분해서 OrderMessage 엔티티를 추가로 생성했습니다.


## 📝 수정 상세 내용 

- Order 엔티티와 Message 엔티티를 연결해주는 OrderMessage 엔티티 생성

## ✅ 체크리스트

- [X] Order 엔티티와 Message 엔티티를 연결해주는 OrderMessage 엔티티 생성

## 📍 레퍼런스

- X