### PR TITLE
[REFACTOR] 서비스 로그 단계별 관리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,6 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'
 
-
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -88,6 +87,9 @@ dependencies {
 
     // Jasypt
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+
+    // Slack-Alarm
+    implementation 'com.github.maricn:logback-slack-appender:1.6.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/doldol_server/doldol/auth/filter/CustomLogoutFilter.java
+++ b/src/main/java/doldol_server/doldol/auth/filter/CustomLogoutFilter.java
@@ -18,7 +18,9 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 public class CustomLogoutFilter extends GenericFilterBean {
 
@@ -46,6 +48,8 @@ public class CustomLogoutFilter extends GenericFilterBean {
         String id = claimsByAccessToken.getSubject();
 
         tokenProvider.deleteRefreshToken(id);
+
+        log.info("로그아웃 완료: userId={}", id);
 
         ResponseUtil.writeNoContent(
                 response,

--- a/src/main/java/doldol_server/doldol/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/doldol_server/doldol/auth/filter/JwtAuthenticationFilter.java
@@ -21,7 +21,9 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
@@ -44,18 +46,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				SecurityContextHolder.getContext().setAuthentication(authentication);
 			}
 		} catch (ExpiredJwtException e) {
+			log.warn("만료된 토큰으로 접근 시도: 토큰 만료");
 			SecurityContextHolder.clearContext();
 			ResponseUtil.writeErrorResponse(response, objectMapper, AuthErrorCode.TOKEN_EXPIRED);
 			return;
 		} catch (IncorrectClaimException e) {
+			log.warn("잘못된 클레임 토큰으로 접근 시도: {}", e.getMessage());
 			SecurityContextHolder.clearContext();
 			ResponseUtil.writeErrorResponse(response, objectMapper, AuthErrorCode.INCORRECT_CLAIM_TOKEN);
 			return;
 		} catch (UsernameNotFoundException e) {
+			log.warn("존재하지 않는 사용자 토큰으로 접근 시도: {}", e.getMessage());
 			SecurityContextHolder.clearContext();
 			ResponseUtil.writeErrorResponse(response, objectMapper, AuthErrorCode.USER_NOT_FOUND);
 			return;
 		} catch (Exception e) {
+			log.warn("유효하지 않은 토큰으로 접근 시도: {}", e.getMessage());
 			SecurityContextHolder.clearContext();
 			ResponseUtil.writeErrorResponse(response, objectMapper, AuthErrorCode.INVALID_TOKEN);
 			return;

--- a/src/main/java/doldol_server/doldol/auth/handler/CustomOAuth2FailureHandler.java
+++ b/src/main/java/doldol_server/doldol/auth/handler/CustomOAuth2FailureHandler.java
@@ -10,7 +10,9 @@ import org.springframework.stereotype.Component;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CustomOAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
@@ -21,6 +23,8 @@ public class CustomOAuth2FailureHandler extends SimpleUrlAuthenticationFailureHa
 	@Override
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException exception) throws IOException {
+
+		log.warn("소셜 로그인 실패: 오류={}", exception.getMessage());
 
 		response.sendRedirect(frontendUrl);
 	}

--- a/src/main/java/doldol_server/doldol/auth/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/doldol_server/doldol/auth/handler/CustomOAuth2SuccessHandler.java
@@ -17,7 +17,9 @@ import doldol_server.doldol.auth.jwt.dto.UserTokenResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
@@ -60,6 +62,10 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 
 	private void handleExistingUser(HttpServletResponse response, CustomUserDetails userDetails,
 		String registrationId) throws IOException {
+
+		log.info("소셜 로그인 성공: userId={}, socialType={}, role={}",
+			userDetails.getUserId(), registrationId.toUpperCase(), userDetails.getRole());
+
 		String userid = String.valueOf(userDetails.getUserId());
 
 		UserTokenResponse loginToken = tokenProvider.createLoginToken(userid, userDetails.getRole());

--- a/src/main/java/doldol_server/doldol/auth/service/AuthService.java
+++ b/src/main/java/doldol_server/doldol/auth/service/AuthService.java
@@ -24,7 +24,9 @@ import doldol_server.doldol.user.repository.UserRepository;
 import doldol_server.doldol.user.service.UserService;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -44,6 +46,7 @@ public class AuthService {
 		boolean isIdExists = userRepository.existsByLoginId(id);
 
 		if (isIdExists) {
+			log.warn("아이디 중복 확인: 이미 존재하는 아이디={}", id);
 			throw new CustomException(AuthErrorCode.ID_DUPLICATED);
 		}
 	}
@@ -78,15 +81,18 @@ public class AuthService {
 		Object result = redisTemplate.opsForValue().get(email);
 
 		if (result == null) {
+			log.warn("인증 코드 만료: email={}", email);
 			throw new CustomException(AuthErrorCode.EMAIL_NOT_FOUND);
 		}
 
 		String verificationCode = result.toString();
 
 		if (!verificationCode.equals(code)) {
+			log.warn("인증 코드 불일치: email={}, 입력코드={}", email, code);
 			throw new CustomException(AuthErrorCode.VERIFICATION_CODE_WRONG);
 		}
 
+		log.info("이메일 인증 완료: email={}", email);
 		redisTemplate.opsForValue().set(email, EMAIL_VERIFIED_KEY, 30, TimeUnit.MINUTES);
 	}
 
@@ -103,6 +109,9 @@ public class AuthService {
 			.build();
 
 		userRepository.save(user);
+
+		log.info("자체 회원가입 완료: userId={}, email={}, name='{}'",
+			user.getId(), user.getEmail(), user.getName());
 	}
 
 	@Transactional
@@ -118,6 +127,9 @@ public class AuthService {
 			.build();
 
 		userRepository.save(user);
+
+		log.info("소셜 회원가입 완료: userId={}, email={}, socialType={}",
+			user.getId(), user.getEmail(), user.getSocialType());
 	}
 
 	@Transactional
@@ -139,6 +151,8 @@ public class AuthService {
 
 		UserTokenResponse newTokens = tokenProvider.createLoginToken(userId, user.getRole().getRole());
 
+		log.info("토큰 재발급 완료: userId={}", userId);
+
 		return ReissueTokenResponse
 			.builder()
 			.accessToken(newTokens.accessToken())
@@ -155,14 +169,22 @@ public class AuthService {
 		}
 
 		if (user.getSocialId() != null) {
-			OAuth2ResponseStrategy strategy = oAuthSeperator.getStrategy(user.getSocialType().name());
-			strategy.unlink(user.getSocialId());
-			user.deleteOAuthInfo();
+			try {
+				OAuth2ResponseStrategy strategy = oAuthSeperator.getStrategy(user.getSocialType().name());
+				strategy.unlink(user.getSocialId());
+				user.deleteOAuthInfo();
+			} catch (Exception e) {
+				log.error("소셜 계정 연동 해제 실패: userId={}, socialType={}, 오류={}",
+					userId, user.getSocialType(), e.getMessage(), e);
+			}
 		}
 
 		user.updateDeleteStatus();
 
 		tokenProvider.deleteRefreshToken(String.valueOf(userId));
+
+		log.info("소셜 계정 연동 해제: userId={}, socialType={}",
+			userId, user.getSocialType());
 	}
 
 	public void validateUserInfo(String name, String email, String phone) {
@@ -205,6 +227,8 @@ public class AuthService {
 		user.updateUserPassword(passwordEncoder.encode(tempPassword));
 
 		emailService.sendEmailTempPassword(email, tempPassword);
+
+		log.info("비밀번호 재설정 완료: email={}, userId={}", email, user.getId());
 	}
 
 	public void checkRegisterInfoDuplicate(String email, String phone) {
@@ -212,10 +236,13 @@ public class AuthService {
 		boolean existsByPhone = userRepository.existsByPhone(phone);
 
 		if (existsByEmail && !existsByPhone) {
+			log.warn("이메일 중복: email={}", email);
 			throw new CustomException(AuthErrorCode.EMAIl_DUPLICATED);
 		} else if (!existsByEmail && existsByPhone) {
+			log.warn("전화번호 중복: phone={}", phone);
 			throw new CustomException(AuthErrorCode.PHONE_DUPLICATED);
 		} else if (existsByEmail && existsByPhone) {
+			log.warn("이메일/전화번호 모두 중복: email={}, phone={}", email, phone);
 			throw new CustomException(AuthErrorCode.EMAIL_PHONE_DUPLICATED);
 		}
 	}

--- a/src/main/java/doldol_server/doldol/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/doldol_server/doldol/auth/service/CustomOAuth2UserService.java
@@ -20,7 +20,9 @@ import doldol_server.doldol.user.entity.User;
 import doldol_server.doldol.user.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
@@ -51,6 +53,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 		}
 
 		else if (socialLinkedUser.isPresent() && socialLinkedUser.get().isDeleted()) {
+			log.warn("탈퇴한 계정으로 소셜 로그인 시도: socialId={}, socialType={}",
+				oAuth2Response.getSocialId(), registrationId);
 			throw new CustomOAuth2Exception(AuthErrorCode.ALREADY_WITHDRAWN);
 		}
 

--- a/src/main/java/doldol_server/doldol/auth/service/EmailService.java
+++ b/src/main/java/doldol_server/doldol/auth/service/EmailService.java
@@ -14,7 +14,9 @@ import doldol_server.doldol.common.exception.errorCode.MailErrorCode;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EmailService {
@@ -29,7 +31,9 @@ public class EmailService {
 		}
 		try {
 			sendToEmailCode(email, verificationCode);
+			log.info("인증 코드 이메일 발송 완료: email={}", email);
 		} catch (MessagingException e) {
+			log.error("인증 코드 이메일 발송 실패: email={}, 오류={}", email, e.getMessage(), e);
 			throw new CustomException(MailErrorCode.EMAIL_SENDING_ERROR);
 		}
 	}
@@ -41,7 +45,9 @@ public class EmailService {
 		}
 		try {
 			sendToEmailTempPassword(email, password);
+			log.info("임시 비밀번호 이메일 발송 완료: email={}", email);
 		} catch (MessagingException e) {
+			log.error("임시 비밀번호 이메일 발송 실패: email={}, 오류={}", email, e.getMessage(), e);
 			throw new CustomException(MailErrorCode.EMAIL_SENDING_ERROR);
 		}
 	}

--- a/src/main/java/doldol_server/doldol/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/doldol_server/doldol/common/exception/GlobalExceptionHandler.java
@@ -17,7 +17,9 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -27,6 +29,8 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(value = CustomException.class)
 	public ResponseEntity<ErrorResponse<Void>> handleCustomException(CustomException e) {
 		ErrorCode errorCode = e.getErrorCode();
+		log.warn("커스텀 예외 발생: 코드={}, 메시지={}", errorCode.getCode(), e.getMessage());
+
 		return ResponseEntity.status(errorCode.getHttpStatus())
 			.body(ErrorResponse.error(errorCode.getCode(), e.getMessage()));
 	}
@@ -44,6 +48,8 @@ public class GlobalExceptionHandler {
 			errors.put(fieldError.getField(), fieldError.getDefaultMessage());
 		}
 
+		log.warn("유효성 검사 실패: 필드 오류={}", errors);
+
 		CommonErrorCode errorCode = CommonErrorCode.INVALID_VALUE;
 		return ResponseEntity.status(errorCode.getHttpStatus())
 			.body(ErrorResponse.error(errors, errorCode.getCode(), errorCode.getMessage()));
@@ -54,6 +60,8 @@ public class GlobalExceptionHandler {
 	 */
 	@ExceptionHandler(AuthenticationException.class)
 	public ResponseEntity<ErrorResponse<Void>> handleAuthenticationException(AuthenticationException e) {
+		log.warn("인증 예외 발생: {}", e.getMessage());
+
 		AuthErrorCode errorCode = AuthErrorCode.INVALID_TOKEN;
 		return ResponseEntity.status(errorCode.getHttpStatus())
 			.body(ErrorResponse.error(errorCode.getCode(), errorCode.getMessage()));
@@ -64,6 +72,8 @@ public class GlobalExceptionHandler {
 	 */
 	@ExceptionHandler(AccessDeniedException.class)
 	public ResponseEntity<ErrorResponse<Void>> handleAccessDeniedException(AccessDeniedException e) {
+		log.warn("접근 권한 없음: {}", e.getMessage());
+
 		AuthErrorCode errorCode = AuthErrorCode.ACCESS_DENIED;
 		return ResponseEntity.status(errorCode.getHttpStatus())
 			.body(ErrorResponse.error(errorCode.getCode(), errorCode.getMessage()));
@@ -74,6 +84,8 @@ public class GlobalExceptionHandler {
 	 */
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<ErrorResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
+		log.warn("잘못된 인자: {}", e.getMessage());
+
 		CommonErrorCode errorCode = CommonErrorCode.INVALID_ARGUMENT;
 		return ResponseEntity.status(errorCode.getHttpStatus())
 			.body(ErrorResponse.error(errorCode.getCode(), errorCode.getMessage()));
@@ -84,6 +96,8 @@ public class GlobalExceptionHandler {
 	 */
 	@ExceptionHandler(RuntimeException.class)
 	public ResponseEntity<ErrorResponse<Void>> handleRuntimeException(RuntimeException e) {
+		log.error("런타임 예외 발생: {}", e.getMessage(), e);
+
 		CommonErrorCode errorCode = CommonErrorCode.RUNTIME_ERROR;
 		return ResponseEntity.status(errorCode.getHttpStatus())
 			.body(ErrorResponse.error(errorCode.getCode(), errorCode.getMessage()));
@@ -94,6 +108,8 @@ public class GlobalExceptionHandler {
 	 */
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ErrorResponse<Void>> handleGeneralException(Exception e) {
+		log.error("예상치 못한 예외 발생: {}", e.getMessage(), e);
+
 		CommonErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
 		return ResponseEntity.status(errorCode.getHttpStatus())
 			.body(ErrorResponse.error(errorCode.getCode(), errorCode.getMessage()));
@@ -105,8 +121,21 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(MissingServletRequestParameterException.class)
 	public ResponseEntity<ErrorResponse<Void>> handleMissingServletRequestParameterException(
 		MissingServletRequestParameterException e) {
+		log.warn("필수 파라미터 누락: 파라미터={}, 타입={}", e.getParameterName(), e.getParameterType());
+
 		CommonErrorCode errorCode = CommonErrorCode.MISSING_PARAMETER;
 		return ResponseEntity.status(errorCode.getHttpStatus())
 			.body(ErrorResponse.error(errorCode.getCode(), errorCode.getMessage()));
+	}
+
+	/**
+	 * OAuth2 연동 해제 예외
+	 */
+	@ExceptionHandler(OAuth2UnlinkException.class)
+	public ResponseEntity<ErrorResponse<Void>> handleOAuth2UnlinkException(OAuth2UnlinkException e) {
+		log.error("OAuth2 연동 해제 실패: 코드={}, 메시지={}", e.getErrorCode().getCode(), e.getMessage(), e);
+
+		return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+			.body(ErrorResponse.error(e.getErrorCode().getCode(), e.getMessage()));
 	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/PaperService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/PaperService.java
@@ -22,7 +22,9 @@ import doldol_server.doldol.rollingPaper.entity.Paper;
 import doldol_server.doldol.rollingPaper.entity.Participant;
 import doldol_server.doldol.rollingPaper.repository.PaperRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -44,6 +46,9 @@ public class PaperService {
 
 		participantService.addUser(userId, paper, true);
 
+		log.info("롤링페이퍼 생성 완료: paperId={}, 제목='{}', 생성자={}, 공개날짜={}",
+			paper.getId(), paper.getName(), userId, paper.getOpenDate());
+
 		return CreatePaperResponse.of(paper);
 	}
 
@@ -59,6 +64,9 @@ public class PaperService {
 		participantService.validateJoinable(userId, paper.getId());
 
 		participantService.addUser(userId, paper, false);
+
+		log.info("롤링페이퍼 참여 완료: paperId={}, 참여자={}, 제목='{}'",
+			paper.getId(), userId, paper.getName());
 	}
 
 	public PaperListResponse getMyRollingPapers(CursorPageRequest request,
@@ -83,6 +91,9 @@ public class PaperService {
 
 	private Paper getByInvitationCode(String invitationCode) {
 		return paperRepository.findByInvitationCode(invitationCode)
-			.orElseThrow(() -> new CustomException(PAPER_NOT_FOUND));
+			.orElseThrow(() -> {
+				log.warn("유효하지 않은 초대 코드로 접근: invitationCode={}", invitationCode);
+				return new CustomException(PAPER_NOT_FOUND);
+			});
 	}
 }

--- a/src/main/java/doldol_server/doldol/rollingPaper/service/ParticipantService.java
+++ b/src/main/java/doldol_server/doldol/rollingPaper/service/ParticipantService.java
@@ -38,6 +38,9 @@ public class ParticipantService {
 		paper.addParticipant();
 
 		participantRepository.save(participant);
+
+		log.info("참여자 추가 완료: paperId={}, userId={}, 마스터여부={}",
+			paper.getId(), userId, isMaster);
 	}
 
 	public CursorPage<ParticipantResponse, ParticipantsCursorResponse> getParticipants(Long paperId,
@@ -75,12 +78,14 @@ public class ParticipantService {
 
 	private void alreadyExistUser(Long userId, List<Participant> participants) {
 		if (participants.stream().anyMatch(participant -> participant.getUser().getId().equals(userId))) {
+			log.warn("이미 참여 중인 사용자의 중복 참여 시도: userId={}", userId);
 			throw new CustomException(PARTICIPANT_ALREADY_EXIST);
 		}
 	}
 
 	private void existPaper(List<Participant> participants) {
 		if (participants.isEmpty()) {
+			log.warn("존재하지 않는 롤링페이퍼 접근 시도");
 			throw new CustomException(PAPER_NOT_FOUND);
 		}
 	}

--- a/src/main/java/doldol_server/doldol/user/service/UserService.java
+++ b/src/main/java/doldol_server/doldol/user/service/UserService.java
@@ -11,7 +11,9 @@ import doldol_server.doldol.user.dto.response.UserResponse;
 import doldol_server.doldol.user.entity.User;
 import doldol_server.doldol.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -21,17 +23,37 @@ public class UserService {
 	private final PasswordEncoder passwordEncoder;
 
 	public User getById(Long userId) {
-		return userRepository.findById(userId).orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+		return userRepository.findById(userId)
+			.orElseThrow(() -> {
+				log.warn("존재하지 않는 사용자 조회 시도: userId={}", userId);
+				return new CustomException(UserErrorCode.USER_NOT_FOUND);
+			});
 	}
 
 	@Transactional
 	public void changeInfo(UpdateUserInfoRequest request, Long userId) {
 		User user = getById(userId);
+
+		boolean nameUpdated = false;
+		boolean passwordUpdated = false;
+
 		if (request.name() != null) {
 			user.updateUserName(request.name());
+			nameUpdated = true;
 		}
 		if (request.password() != null) {
 			user.updateUserPassword(passwordEncoder.encode(request.password()));
+			passwordUpdated = true;
+		}
+
+		if (nameUpdated && passwordUpdated) {
+			log.info("사용자 정보 수정 완료: userId={}, 수정항목=이름+비밀번호", userId);
+		} else if (nameUpdated) {
+			log.info("사용자 정보 수정 완료: userId={}, 수정항목=이름", userId);
+		} else if (passwordUpdated) {
+			log.info("사용자 정보 수정 완료: userId={}, 수정항목=비밀번호", userId);
+		} else {
+			log.warn("사용자 정보 수정 요청했으나 변경사항 없음: userId={}", userId);
 		}
 	}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,16 @@ spring:
         highlight_sql: true
   application:
     name: doldol
+
+logging:
+  level:
+    org.hibernate.SQL: info
+    doldol_server.doldol: info
+  slack:
+    dev:
+      webhook-uri: ""
+    prod:
+      warn:
+        webhook-uri: ""
+      error:
+        webhook-uri: ""

--- a/src/main/resources/console-appender.xml
+++ b/src/main/resources/console-appender.xml
@@ -1,0 +1,7 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/file-error-appender.xml
+++ b/src/main/resources/file-error-appender.xml
@@ -1,0 +1,14 @@
+<included>
+    <appender name="FILE-ERROR" class="ch.qos.logback.core.FileAppender">
+        <file>/app/logs/error/error-${BY_DATE}.log</file>
+        <append>true</append>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/file-info-appender.xml
+++ b/src/main/resources/file-info-appender.xml
@@ -1,0 +1,14 @@
+<included>
+    <appender name="FILE-INFO" class="ch.qos.logback.core.FileAppender">
+        <file>/app/logs/info/info-${BY_DATE}.log</file>
+        <append>true</append>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,46 @@
+<configuration>
+    <!-- 기본 설정 -->
+    <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
+    <property name="LOG_PATTERN"
+              value="[%d{yyyy-MM-dd'T'HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+
+    <!-- 슬랙 설정 - 채널별 분리 -->
+    <springProperty name="SLACK_DEV_WEBHOOK_URI" source="logging.slack.dev.webhook-uri"/>
+    <springProperty name="SLACK_PROD_WARN_WEBHOOK_URI" source="logging.slack.prod.warn.webhook-uri"/>
+    <springProperty name="SLACK_PROD_ERROR_WEBHOOK_URI" source="logging.slack.prod.error.webhook-uri"/>
+
+    <!-- 로컬 환경: 콘솔 출력만 -->
+    <springProfile name="local">
+        <include resource="console-appender.xml"/>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <!-- 개발 환경: 파일 저장 + dev 슬랙 채널 -->
+    <springProfile name="dev">
+        <include resource="file-info-appender.xml"/>
+        <include resource="file-error-appender.xml"/>
+        <include resource="slack-dev-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="FILE-INFO"/>
+            <appender-ref ref="FILE-ERROR"/>
+            <appender-ref ref="ASYNC_SLACK_DEV"/>
+        </root>
+    </springProfile>
+
+    <!-- 운영 환경: 파일 저장 + 2개 슬랙 채널 분리 -->
+    <springProfile name="prod">
+        <include resource="file-info-appender.xml"/>
+        <include resource="file-error-appender.xml"/>
+        <include resource="slack-prod-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="FILE-INFO"/>
+            <appender-ref ref="FILE-ERROR"/>
+            <appender-ref ref="ASYNC_SLACK_PROD_WARN"/>
+            <appender-ref ref="ASYNC_SLACK_PROD_ERROR"/>
+        </root>
+    </springProfile>
+</configuration>

--- a/src/main/resources/slack-dev-appender.xml
+++ b/src/main/resources/slack-dev-appender.xml
@@ -1,0 +1,25 @@
+<included>
+    <appender name="SLACK_DEV" class="com.github.maricn.logback.SlackAppender">
+        <webhookUri>${SLACK_DEV_WEBHOOK_URI}</webhookUri>
+        <channel>#be-dev-log</channel>
+        <username>doldol-dev</username>
+        <iconEmoji>:hammer_and_wrench:</iconEmoji>
+        <colorCoding>true</colorCoding>
+
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>[%level] %d{HH:mm:ss} %logger{20} - %msg</pattern>
+        </layout>
+
+        <includeAttachment>false</includeAttachment>
+    </appender>
+
+    <appender name="ASYNC_SLACK_DEV" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="SLACK_DEV"/>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+        <discardingThreshold>0</discardingThreshold>
+        <queueSize>512</queueSize>
+        <includeCallerData>false</includeCallerData>
+    </appender>
+</included>

--- a/src/main/resources/slack-prod-appender.xml
+++ b/src/main/resources/slack-prod-appender.xml
@@ -1,0 +1,60 @@
+<included>
+    <!-- 운영환경 WARN 전용 -->
+    <appender name="SLACK_PROD_WARN" class="com.github.maricn.logback.SlackAppender">
+        <webhookUri>${SLACK_PROD_WARN_WEBHOOK_URI}</webhookUri>
+        <channel>#be-prod-warn-log</channel>
+        <username>doldol-prod-warn</username>
+        <iconEmoji>:warning:</iconEmoji>
+        <colorCoding>true</colorCoding>
+
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>WARNING %d{HH:mm:ss} %logger{20} - %msg</pattern>
+        </layout>
+
+        <includeAttachment>false</includeAttachment>
+    </appender>
+
+    <!-- 운영환경 ERROR 전용 -->
+    <appender name="SLACK_PROD_ERROR" class="com.github.maricn.logback.SlackAppender">
+        <webhookUri>${SLACK_PROD_ERROR_WEBHOOK_URI}</webhookUri>
+        <channel>#be-prod-error-log</channel>
+        <username>doldol-prod-error</username>
+        <iconEmoji>:rotating_light:</iconEmoji>
+        <colorCoding>true</colorCoding>
+
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>CRITICAL ERROR - Server: doldol-prod - Time: %d{yyyy-MM-dd HH:mm:ss} - Thread: %thread - Logger: %logger{36} - Message: %msg</pattern>
+        </layout>
+
+        <includeAttachment>true</includeAttachment>
+        <attachmentFallback>Production Error - Immediate Action Required</attachmentFallback>
+        <attachmentColor>danger</attachmentColor>
+        <attachmentTitle>PRODUCTION ERROR ALERT</attachmentTitle>
+    </appender>
+
+    <!-- WARN 전용 비동기 처리 -->
+    <appender name="ASYNC_SLACK_PROD_WARN" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="SLACK_PROD_WARN"/>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <discardingThreshold>20</discardingThreshold>
+        <queueSize>256</queueSize>
+        <includeCallerData>false</includeCallerData>
+    </appender>
+
+    <!-- ERROR 전용 비동기 처리 -->
+    <appender name="ASYNC_SLACK_PROD_ERROR" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="SLACK_PROD_ERROR"/>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <discardingThreshold>0</discardingThreshold>
+        <queueSize>128</queueSize>
+        <includeCallerData>true</includeCallerData>
+    </appender>
+</included>


### PR DESCRIPTION
## 📄 PR 내용

- profile 별, log 레벨 별 알림을 slack에 전송

## 📝 수정 상세 내용 

- local에서는 터미널 콘솔에 로그 출력
- dev에서는 슬랙 채널(#be-dev) 하나에 모든 로그 알림 전송
- prod에서는 슬랙 채널(#be-prod-warn, #be-prod-error) 채널에 warn, error 로그 전송

## ✅ 체크리스트

- [X] slack 연동
- [X] 로그 파일 분리

## 📍 레퍼런스

- X